### PR TITLE
Add score method and tests for ModalBoundaryClustering

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -537,6 +537,11 @@ class ModalBoundaryClustering(BaseEstimator):
         self._log(f"predict_proba completado en {runtime:.4f}s")
         return result
 
+    def score(self, X: Union[np.ndarray, pd.DataFrame], y: np.ndarray) -> float:
+        """Devuelve la métrica de sklearn delegando en el pipeline interno."""
+        check_is_fitted(self, "pipeline_")
+        return self.pipeline_.score(np.asarray(X, dtype=float), y)
+
     def interpretability_summary(self, feature_names: Optional[List[str]] = None) -> pd.DataFrame:
         check_is_fitted(self, "regions_")
         d = self.n_features_in_

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,7 +1,8 @@
 # tests/test_basic.py
 import numpy as np
-from sklearn.datasets import load_iris
+from sklearn.datasets import load_iris, make_regression
 from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestRegressor
 from sheshe import ModalBoundaryClustering
 
 def test_import_and_fit():
@@ -15,3 +16,17 @@ def test_import_and_fit():
     assert proba.shape[0] == 3
     df = sh.interpretability_summary(iris.feature_names)
     assert {"Tipo","Distancia","Categoria"}.issubset(df.columns)
+    score = sh.score(X, y)
+    assert 0.0 <= score <= 1.0
+
+
+def test_score_regression():
+    X, y = make_regression(n_samples=100, n_features=4, noise=0.1, random_state=0)
+    sh = ModalBoundaryClustering(
+        base_estimator=RandomForestRegressor(n_estimators=10, random_state=0),
+        task="regression",
+        random_state=0,
+    )
+    sh.fit(X, y)
+    score = sh.score(X, y)
+    assert np.isfinite(score)


### PR DESCRIPTION
## Summary
- Implement `ModalBoundaryClustering.score` using scikit-learn pipeline scoring with fitted check
- Extend basic test to exercise scoring and add regression score test

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ad8b3e914832ca799f354ca76cef0