### PR TITLE
Add joblib save/load support to ModalBoundaryClustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ reg = ModalBoundaryClustering(task="regression")
   - `valor_real` / `valor_norm`
   - `coord_0..coord_{d-1}` o nombres de features
 - `plot_pairs(X, y=None, max_pairs=None)` → gráficos 2D para todas las combinaciones de pares
+- `save(filepath)` → guarda la instancia entrenada con `joblib`
+- `ModalBoundaryClustering.load(filepath)` → recupera una instancia guardada
 
 ---
 
@@ -100,6 +102,20 @@ sh.fit(X, y)
 
 print(sh.interpretability_summary(diab.feature_names).head())
 sh.plot_pairs(X, max_pairs=3)
+```
+
+### Guardado y carga
+```python
+from pathlib import Path
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+sh = ModalBoundaryClustering(random_state=0).fit(X, y)
+path = Path("mbc_model.joblib")
+sh.save(path)
+sh2 = ModalBoundaryClustering.load(path)
+print((sh.predict(X[:5]) == sh2.predict(X[:5])).all())
 ```
 
 Para ejemplos más completos, consulta la carpeta `examples/`.

--- a/examples/save_load_demo.py
+++ b/examples/save_load_demo.py
@@ -1,0 +1,19 @@
+# examples/save_load_demo.py
+"""Demostración de guardado y carga de ModalBoundaryClustering."""
+from pathlib import Path
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+
+def main() -> None:
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    sh = ModalBoundaryClustering(random_state=0).fit(X, y)
+    model_path = Path(__file__).with_suffix(".joblib")
+    sh.save(model_path)
+    sh2 = ModalBoundaryClustering.load(model_path)
+    print("Predicciones iguales:", (sh.predict(X[:5]) == sh2.predict(X[:5])).all())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import joblib
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -271,6 +272,7 @@ class ModalBoundaryClustering(BaseEstimator):
       - `direction`: 'center_out' (default) o 'outside_in' para localizar la inflexión.
       - Pendiente en punto de inflexión (df/dt).
       - Ascenso con barreras en bordes.
+      - Métodos `save` y `load` para persistencia vía joblib.
     """
 
     def __init__(
@@ -536,6 +538,35 @@ class ModalBoundaryClustering(BaseEstimator):
         runtime = time.perf_counter() - start
         self._log(f"predict_proba completado en {runtime:.4f}s")
         return result
+
+    def save(self, filepath: Union[str, Path]) -> None:
+        """Guarda la instancia en ``filepath`` usando :mod:`joblib`.
+
+        Parameters
+        ----------
+        filepath:
+            Ruta donde almacenar el objeto serializado.
+        """
+        joblib.dump(self, filepath)
+
+    @classmethod
+    def load(cls, filepath: Union[str, Path]) -> "ModalBoundaryClustering":
+        """Carga una instancia previamente guardada con :meth:`save`.
+
+        Parameters
+        ----------
+        filepath:
+            Ruta al archivo generado por :meth:`save`.
+
+        Returns
+        -------
+        ModalBoundaryClustering
+            La instancia recuperada.
+        """
+        obj = joblib.load(filepath)
+        if not isinstance(obj, cls):
+            raise TypeError("El objeto cargado no es ModalBoundaryClustering")
+        return obj
 
     def interpretability_summary(self, feature_names: Optional[List[str]] = None) -> pd.DataFrame:
         check_is_fitted(self, "regions_")

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,0 +1,13 @@
+# tests/test_save_load.py
+import numpy as np
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+
+def test_save_and_load(tmp_path):
+    X, y = load_iris(return_X_y=True)
+    sh = ModalBoundaryClustering(random_state=0).fit(X, y)
+    path = tmp_path / "model.joblib"
+    sh.save(path)
+    sh2 = ModalBoundaryClustering.load(path)
+    assert np.all(sh.predict(X[:10]) == sh2.predict(X[:10]))


### PR DESCRIPTION
## Summary
- add `save` and `load` methods to `ModalBoundaryClustering` for joblib-based persistence
- document new persistence methods and usage example in README and add example script
- include tests verifying that a saved model can be loaded and used

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ad8add764832c96326d45a2b9e4f7