### PR TITLE
Add model persistence utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ reg = ModalBoundaryClustering(task="regression")
   - `valor_real` / `valor_norm`
   - `coord_0..coord_{d-1}` o nombres de features
 - `plot_pairs(X, y=None, max_pairs=None)` → gráficos 2D para todas las combinaciones de pares
+- `save(filepath)` → guarda el modelo mediante `joblib`
+- `ModalBoundaryClustering.load(filepath)` → carga una instancia guardada
 
 ---
 
@@ -158,6 +160,22 @@ for i, fig_num in enumerate(plt.get_fignums()):
     plt.figure(fig_num)
     plt.savefig(out_dir / f"pair_{i}.png")
     plt.close(fig_num)
+```
+
+### Guardar y cargar modelo
+```python
+from pathlib import Path
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+sh = ModalBoundaryClustering().fit(X, y)
+ruta = Path("sheshe_model.joblib")
+sh.save(ruta)
+sh2 = ModalBoundaryClustering.load(ruta)
+print((sh.predict(X) == sh2.predict(X)).all())
 ```
 
 Para ejemplos más completos, consulta la carpeta `examples/`.

--- a/examples/save_load_demo.py
+++ b/examples/save_load_demo.py
@@ -1,0 +1,19 @@
+# examples/save_load_demo.py
+from pathlib import Path
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+
+def main():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+
+    model = ModalBoundaryClustering(random_state=0).fit(X, y)
+    path = Path("sheshe_model.joblib")
+    model.save(path)
+    loaded = ModalBoundaryClustering.load(path)
+    print("Predicciones iguales:", (model.predict(X) == loaded.predict(X)).all())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+import joblib
 
 from sklearn.base import BaseEstimator, clone
 from sklearn.preprocessing import StandardScaler
@@ -550,6 +551,15 @@ class ModalBoundaryClustering(BaseEstimator):
         """Devuelve la métrica de sklearn delegando en el pipeline interno."""
         check_is_fitted(self, "pipeline_")
         return self.pipeline_.score(np.asarray(X, dtype=float), y)
+
+    def save(self, filepath: Union[str, Path]) -> None:
+        """Guarda la instancia actual en ``filepath`` usando ``joblib.dump``."""
+        joblib.dump(self, filepath)
+
+    @classmethod
+    def load(cls, filepath: Union[str, Path]) -> "ModalBoundaryClustering":
+        """Carga una instancia previamente guardada con :meth:`save`."""
+        return joblib.load(filepath)
 
     def interpretability_summary(self, feature_names: Optional[List[str]] = None) -> pd.DataFrame:
         check_is_fitted(self, "regions_")


### PR DESCRIPTION
## Summary
- add `save` and `load` methods to `ModalBoundaryClustering` using joblib
- document persistence in README with example
- provide example script demonstrating saving and loading a model

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ada42dc78832ca870f4cffd50f002