### PR TITLE
Validate scan steps minimum

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -293,6 +293,9 @@ class ModalBoundaryClustering(BaseEstimator):
         save_labels: bool = False,
         out_dir: Optional[Union[str, Path]] = None,
     ):
+        if scan_steps < 2:
+            raise ValueError("scan_steps must be at least 2")
+
         self.base_estimator = base_estimator
         self.task = task
         self.base_2d_rays = base_2d_rays

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,6 @@
 # tests/test_basic.py
 import numpy as np
+import pytest
 from sklearn.datasets import load_iris, make_regression
 from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
@@ -72,3 +73,8 @@ def test_decision_function_regression_fallback():
     expected = sh.estimator_.predict(Xs)
     df_scores = sh.decision_function(X[:5])
     assert np.allclose(df_scores, expected)
+
+
+def test_scan_steps_minimum():
+    with pytest.raises(ValueError):
+        ModalBoundaryClustering(scan_steps=1)


### PR DESCRIPTION
## Summary
- validate that `scan_steps` is at least 2 in `ModalBoundaryClustering`'s constructor
- add unit test ensuring invalid `scan_steps` raises a `ValueError`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689adbf00608832c913b18891bb6beb8