### PR TITLE
Validate n_max_seeds and add test

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -293,6 +293,9 @@ class ModalBoundaryClustering(BaseEstimator):
         save_labels: bool = False,
         out_dir: Optional[Union[str, Path]] = None,
     ):
+        if n_max_seeds < 1:
+            raise ValueError("n_max_seeds debe ser >= 1")
+
         self.base_estimator = base_estimator
         self.task = task
         self.base_2d_rays = base_2d_rays
@@ -357,6 +360,8 @@ class ModalBoundaryClustering(BaseEstimator):
 
     def _find_maximum(self, X: np.ndarray, f, bounds: Tuple[np.ndarray, np.ndarray]) -> np.ndarray:
         seeds = self._choose_seeds(X, f, min(self.n_max_seeds, len(X)))
+        if len(seeds) == 0:
+            return X[0]
         best_x, best_v = seeds[0].copy(), f(seeds[0])
         for s in seeds:
             x_star = gradient_ascent(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,6 @@
 # tests/test_basic.py
 import numpy as np
+import pytest
 from sklearn.datasets import load_iris, make_regression
 from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
@@ -72,3 +73,8 @@ def test_decision_function_regression_fallback():
     expected = sh.estimator_.predict(Xs)
     df_scores = sh.decision_function(X[:5])
     assert np.allclose(df_scores, expected)
+
+
+def test_n_max_seeds_must_be_positive():
+    with pytest.raises(ValueError):
+        ModalBoundaryClustering(n_max_seeds=0)


### PR DESCRIPTION
## Summary
- ensure `ModalBoundaryClustering` rejects `n_max_seeds < 1`
- fallback to first data point when no seeds are chosen
- cover `n_max_seeds=0` with a dedicated test

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689adbf1d2b4832c8c3f104dcf90c925