### PR TITLE
Optimize subspace sampling and add high-dimensional test

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -233,9 +233,16 @@ def generate_directions(dim: int, base_2d: int, random_state: Optional[int] = 42
 
     # elige subespacios de tamaño 3 (o 2 si dim=4 y quieres más baratas)
     sub_dim = 3 if dim >= 3 else 2
-    combos = list(itertools.combinations(range(dim), sub_dim))
+    total_combos = math.comb(dim, sub_dim)
+    if max_subspaces >= total_combos:
+        combos = list(itertools.combinations(range(dim), sub_dim))
+    else:
+        combos = set()
+        while len(combos) < max_subspaces:
+            combo = tuple(sorted(rng.choice(dim, size=sub_dim, replace=False)))
+            combos.add(combo)
+        combos = list(combos)
     rng.shuffle(combos)
-    combos = combos[:max_subspaces]
 
     # nº de rays por subespacio
     if sub_dim == 3:

--- a/tests/test_high_dim.py
+++ b/tests/test_high_dim.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from sheshe.sheshe import generate_directions, rays_count_auto
+
+
+def test_generate_directions_high_dimension():
+    dim = 100
+    base_2d = 8
+    max_subspaces = 10
+    D = generate_directions(dim, base_2d, random_state=0, max_subspaces=max_subspaces)
+    n_global = rays_count_auto(dim, base_2d)
+    n_local = rays_count_auto(3, base_2d)
+    assert D.shape == (n_global + max_subspaces * n_local, dim)
+    local_rows = D[n_global:]
+    supports = set()
+    for i in range(0, local_rows.shape[0], n_local):
+        block = local_rows[i:i + n_local]
+        support = tuple(np.where(np.any(np.abs(block) > 1e-8, axis=0))[0])
+        assert len(support) == 3
+        supports.add(support)
+    assert len(supports) == max_subspaces


### PR DESCRIPTION
## Summary
- Sample random subspaces without enumerating all combinations for high-dimensional direction generation
- Add a regression test covering high-dimensional direction sampling

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689adbf92e40832c8687f8591b8cb340