### PR TITLE
Handle regions without directions

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -480,6 +480,10 @@ class ModalBoundaryClustering(BaseEstimator):
         n = len(X)
         R = np.zeros((n, len(self.regions_)), dtype=int)
         for k, reg in enumerate(self.regions_):
+            if reg.directions.size == 0:
+                # región sin direcciones: ningún punto pertenece
+                R[:, k] = 0
+                continue
             c = reg.center
             V = X - c
             norms = np.linalg.norm(V, axis=1) + 1e-12

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,6 @@
 # tests/test_basic.py
 import numpy as np
-from sklearn.datasets import load_iris, make_regression
+from sklearn.datasets import load_iris, make_regression, make_classification
 from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
 from sheshe import ModalBoundaryClustering
@@ -72,3 +72,19 @@ def test_decision_function_regression_fallback():
     expected = sh.estimator_.predict(Xs)
     df_scores = sh.decision_function(X[:5])
     assert np.allclose(df_scores, expected)
+
+
+def test_membership_matrix_handles_zero_directions():
+    X, y = make_classification(
+        n_samples=30, n_features=2, n_redundant=0,
+        n_informative=2, random_state=0
+    )
+    sh = ModalBoundaryClustering(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification", base_2d_rays=0, random_state=0,
+    )
+    sh.fit(X, y)
+    M = sh._membership_matrix(X)
+    assert np.all(M == 0)
+    y_pred = sh.predict(X)
+    assert np.array_equal(y_pred, sh.pipeline_.predict(X))


### PR DESCRIPTION
## Summary
- avoid errors when a region has no directions by treating all points as outside
- add regression test for base_2d_rays=0 ensuring membership matrix handles zero directions

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689adbf69088832c9f4f51854a22463c