### PR TITLE
Add validation for plot_pairs classification input length

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -758,6 +758,7 @@ class ModalBoundaryClustering(BaseEstimator):
 
         if self.task == "classification":
             assert y is not None, "y requerido para graficar clasificación."
+            assert len(y) == len(X), "X e y deben tener la misma longitud."
             palette = ["#e41a1c", "#377eb8", "#4daf4a", "#984ea3",
                        "#ff7f00", "#a65628", "#f781bf", "#999999"]
             class_colors = {c: palette[i % len(palette)] for i, c in enumerate(self.classes_)}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,6 @@
 # tests/test_basic.py
 import numpy as np
+import pytest
 from sklearn.datasets import load_iris, make_regression
 from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
@@ -72,3 +73,16 @@ def test_decision_function_regression_fallback():
     expected = sh.estimator_.predict(Xs)
     df_scores = sh.decision_function(X[:5])
     assert np.allclose(df_scores, expected)
+
+
+def test_plot_pairs_y_length_mismatch():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    sh = ModalBoundaryClustering(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        random_state=0,
+    )
+    sh.fit(X, y)
+    with pytest.raises(AssertionError):
+        sh.plot_pairs(X, y[:-1])


### PR DESCRIPTION
## Summary
- ensure classification plotting checks that `y` matches the number of samples in `X`
- add regression test for mismatched label lengths in `plot_pairs`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689adc0e316c832cbf97df5b7a1fc815