### PR TITLE
style: wrap intro with docstring

### DIFF
--- a/experiments/compare_unsupervised.py
+++ b/experiments/compare_unsupervised.py
@@ -1,4 +1,5 @@
-"""Compara SheShe con algoritmos no supervisados en varios conjuntos de datos.
+"""
+Compara SheShe con algoritmos no supervisados en varios conjuntos de datos.
 
 Genera métricas de *clustering* (ARI, homogeneidad, completitud y V-measure)
 para cinco dataframes distintos y diferentes configuraciones de parámetros.


### PR DESCRIPTION
## Summary
- format compare_unsupervised intro as proper multiline docstring

## Testing
- `PYTHONPATH=src python experiments/compare_unsupervised.py`

------
https://chatgpt.com/codex/tasks/task_e_689adc35570c832c92fdb44c89d56dcf