### PR TITLE
Return base estimator prediction in regression

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -505,12 +505,18 @@ class ModalBoundaryClustering(BaseEstimator):
         X: Union[np.ndarray, pd.DataFrame],
         label_path: Optional[Union[str, Path]] = None,
     ) -> np.ndarray:
+        """Predicción para ``X``.
+
+        Clasificación → etiqueta de la región correspondiente (con *fallback*
+        al estimador base si el punto no pertenece a ninguna). Regresión →
+        valor predicho por el estimador base.
+        """
         start = time.perf_counter()
         try:
             check_is_fitted(self, "regions_")
             X = np.asarray(X, dtype=float)
-            M = self._membership_matrix(X)
             if self.task == "classification":
+                M = self._membership_matrix(X)
                 labels = np.array([reg.label for reg in self.regions_])
                 pred = np.empty(len(X), dtype=labels.dtype)
                 some = M.sum(axis=1) > 0
@@ -527,7 +533,7 @@ class ModalBoundaryClustering(BaseEstimator):
                     pred[none] = base_pred
                 result = pred
             else:
-                result = M[:, 0]
+                result = self.pipeline_.predict(X)
         except Exception as exc:
             self._log(f"Error en predict: {exc}")
             raise

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -33,6 +33,19 @@ def test_score_regression():
     assert np.isfinite(score)
 
 
+def test_predict_regression_returns_base_estimator_value():
+    X, y = make_regression(n_samples=80, n_features=5, noise=0.1, random_state=0)
+    sh = ModalBoundaryClustering(
+        base_estimator=RandomForestRegressor(n_estimators=10, random_state=0),
+        task="regression",
+        random_state=0,
+    )
+    sh.fit(X, y)
+    expected = sh.pipeline_.predict(X[:5])
+    y_hat = sh.predict(X[:5])
+    assert np.allclose(y_hat, expected)
+
+
 def test_decision_function_classifier_and_fallback():
     iris = load_iris()
     X, y = iris.data, iris.target


### PR DESCRIPTION
## Summary
- Clarify `predict` behavior and have regression delegate to the base estimator's output instead of returning a membership flag
- Document `predict` behavior for classification and regression
- Test that regression `predict` mirrors the underlying estimator

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ae12629e8832c837aef63f6af80c0