### PR TITLE
Handle empty region directions

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -490,6 +490,10 @@ class ModalBoundaryClustering(BaseEstimator):
         n = len(X)
         R = np.zeros((n, len(self.regions_)), dtype=int)
         for k, reg in enumerate(self.regions_):
+            if reg.directions.size == 0:
+                raise ValueError(
+                    "Region con número de direcciones cero; revise base_2d_rays"
+                )
             c = reg.center
             V = X - c
             norms = np.linalg.norm(V, axis=1) + 1e-12

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -78,3 +78,17 @@ def test_decision_function_regression_fallback():
 def test_scan_steps_minimum():
     with pytest.raises(ValueError):
         ModalBoundaryClustering(scan_steps=1)
+
+
+def test_membership_matrix_no_directions():
+    iris = load_iris()
+    X, y = iris.data[:, :2], iris.target
+    sh = ModalBoundaryClustering(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        base_2d_rays=0,
+        random_state=0,
+    )
+    sh.fit(X, y)
+    with pytest.raises(ValueError, match="direcciones"):
+        sh.predict(X)


### PR DESCRIPTION
## Summary
- Raise ValueError in `_membership_matrix` when a region has no directions, guiding users to check `base_2d_rays`
- Add regression test verifying the error path when `base_2d_rays=0`

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b8e2f62a0832c92747c74fcea4850