### PR TITLE
Provide bilingual README and document interpretability summary

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE
 include README.md
+include README.es.md
 recursive-include examples *.py
 recursive-include tests *.py

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,235 @@
+# SheShe
+**Smart High-dimensional Edge Segmentation & Hyperboundary Explorer**
+
+[English version](README.md)
+
+Segmentación de bordes y exploración de hiper-fronteras basada en **máximos locales** de
+la **probabilidad por clase** (clasificación) o del **valor predicho** (regresión).
+
+---
+
+## Instalación
+
+Requiere **Python >=3.9** y se recomienda el uso de un entorno virtual.
+
+```bash
+pip install -e .
+```
+
+Dependencias base: `numpy`, `pandas`, `scikit-learn>=1.1`, `matplotlib`
+
+Para un entorno de desarrollo con pruebas:
+
+```bash
+pip install -e ".[dev]"
+PYTHONPATH=src pytest -q
+```
+
+---
+
+## API rápida
+
+```python
+from sheshe import ModalBoundaryClustering
+
+# clasificación
+clf = ModalBoundaryClustering(
+    base_estimator=None,           # por defecto LogisticRegression
+    task="classification",         # "classification" | "regression"
+    base_2d_rays=8,                # nº de rayos en 2D (≈45°)
+    direction="center_out",        # "center_out" | "outside_in"
+    scan_radius_factor=3.0,
+    scan_steps=64,
+    random_state=0
+)
+
+# regresión (ejemplo)
+reg = ModalBoundaryClustering(task="regression")
+```
+
+### Métodos
+- `fit(X, y)`
+- `predict(X)`
+- `predict_proba(X)`  → clasificación: probas por clase; regresión: valor normalizado [0,1]
+- `interpretability_summary(feature_names=None)` → DataFrame con:
+  - `Tipo`: "centroide" | "inflexion_point"
+  - `Distancia`: radio desde el centro al punto de inflexión
+  - `Categoria`: clase (o "NA" en regresión)
+  - `pendiente`: df/dt en el punto de inflexión
+  - `valor_real` / `valor_norm`
+  - `coord_0..coord_{d-1}` o nombres de features
+- `plot_pairs(X, y=None, max_pairs=None)` → gráficos 2D para todas las combinaciones de pares
+- `save(filepath)` → guarda el modelo mediante `joblib`
+- `ModalBoundaryClustering.load(filepath)` → carga una instancia guardada
+
+---
+
+## ¿Cómo funciona?
+1. Entrena/usa un **modelo base** de sklearn (clasificación con `predict_proba` o regresión con `predict`).
+2. Busca **máximos locales** por **ascenso de gradiente** con barreras en los límites del dominio.
+3. Desde el máximo, traza **rayos** (direcciones) en la hiperesfera:
+   - 2D: 8 rayos por defecto
+   - 3D: ~26 direcciones (cobertura por *caps* esféricos con muestreo Fibonacci)
+   - >3D: mezcla de unas pocas direcciones globales + **subespacios** 2D/3D
+4. Sobre cada rayo, **escanea radialmente** y calcula el **primer punto de inflexión** según `direction`:
+   - `center_out`: desde el centro hacia fuera
+   - `outside_in`: desde el exterior hacia el centro
+   Registra además la **pendiente** (df/dt) en ese punto.
+5. Conecta los puntos de inflexión para formar la **frontera** de la región de alta probabilidad/valor.
+
+---
+
+## Ejemplos
+### Clasificación — Iris
+```python
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+from sheshe import ModalBoundaryClustering
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+sh = ModalBoundaryClustering(
+    base_estimator=LogisticRegression(max_iter=1000),
+    task="classification",
+    base_2d_rays=8,
+    random_state=0,
+).fit(X, y)
+
+print(sh.interpretability_summary(iris.feature_names).head())
+sh.plot_pairs(X, y, max_pairs=3)   # genera las gráficas
+plt.show()
+```
+
+### Clasificación con modelo ya entrenado
+```python
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_wine
+from sklearn.ensemble import RandomForestClassifier
+from sheshe import ModalBoundaryClustering
+
+wine = load_wine()
+X, y = wine.data, wine.target
+
+# Entrena un modelo de forma independiente
+base_model = RandomForestClassifier(n_estimators=200, random_state=0)
+base_model.fit(X, y)
+
+# Usa SheShe con ese modelo ya ajustado
+sh = ModalBoundaryClustering(
+    base_estimator=base_model,
+    task="classification",
+    base_2d_rays=8,
+    random_state=0,
+).fit(X, y)
+
+sh.plot_pairs(X, y, max_pairs=2)
+plt.show()
+```
+
+### Regresión — Diabetes
+```python
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_diabetes
+from sklearn.ensemble import GradientBoostingRegressor
+from sheshe import ModalBoundaryClustering
+
+diab = load_diabetes()
+X, y = diab.data, diab.target
+
+sh = ModalBoundaryClustering(
+    base_estimator=GradientBoostingRegressor(random_state=0),
+    task="regression",
+    base_2d_rays=8,
+    random_state=0,
+).fit(X, y)
+
+print(sh.interpretability_summary(diab.feature_names).head())
+sh.plot_pairs(X, max_pairs=3)
+plt.show()
+```
+
+### Guardado de gráficas
+```python
+from pathlib import Path
+import matplotlib.pyplot as plt
+
+# tras llamar a ``sh.plot_pairs(...)``
+out_dir = Path("imagenes")
+out_dir.mkdir(exist_ok=True)
+for i, fig_num in enumerate(plt.get_fignums()):
+    plt.figure(fig_num)
+    plt.savefig(out_dir / f"pair_{i}.png")
+    plt.close(fig_num)
+```
+
+### Guardar y cargar modelo
+```python
+from pathlib import Path
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+sh = ModalBoundaryClustering().fit(X, y)
+ruta = Path("sheshe_model.joblib")
+sh.save(ruta)
+sh2 = ModalBoundaryClustering.load(ruta)
+print((sh.predict(X) == sh2.predict(X)).all())
+```
+
+Para ejemplos más completos, consulta la carpeta `examples/`.
+
+### Experimentos y benchmark
+
+Los experimentos de comparación con algoritmos **no supervisados** se encuentran
+en la carpeta [`experiments/`](experiments/). El script
+[`compare_unsupervised.py`](experiments/compare_unsupervised.py) evalúa cinco
+conjuntos de datos distintos, explora parámetros de **SheShe**, **KMeans** y
+**DBSCAN**, y almacena cuatro métricas (`ARI`, `homogeneity`, `completeness`,
+`v_measure`) junto con el tiempo de ejecución (`runtime_sec`).
+
+```bash
+python experiments/compare_unsupervised.py
+cat benchmark/unsupervised_results.csv | head
+```
+
+se generan los resultados dentro de `benchmark/`.
+
+---
+
+## Parámetros clave
+- `base_2d_rays` → controla la resolución angular en 2D (8 por defecto). 3D escala ~26; d>3 usa subespacios.
+- `direction` → "center_out" | "outside_in" para localizar el punto de inflexión.
+- `scan_radius_factor`, `scan_steps` → tamaño y resolución del escaneo radial.
+- `grad_*` → hiperparámetros del ascenso (tasa, iteraciones, tolerancias).
+- `max_subspaces` → nº máx. de subespacios considerados cuando d>3.
+
+---
+
+## Limitaciones
+- Depende de la **superficie** producida por el modelo base (puede ser rugosa en RF).
+- En alta dimensión, la frontera es una **aproximación** (subespacios).
+- Encuentra **máximos locales** (no garantiza el global), mitigado con múltiples *seeds*.
+
+---
+
+## Contribuir
+
+Las mejoras son bienvenidas. Para proponer cambios:
+
+1. Haz un *fork* del repositorio y crea una rama descriptiva.
+2. Instala las dependencias de desarrollo y ejecuta los tests:
+
+   ```bash
+   pip install -e ".[dev]"
+   PYTHONPATH=src pytest -q
+   ```
+3. Envía un *pull request* con una descripción clara del cambio.
+
+---
+
+## Licencia
+MIT

--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
-# SheShe  
+# SheShe
 **Smart High-dimensional Edge Segmentation & Hyperboundary Explorer**
 
-Segmentación de bordes y exploración de hiper-fronteras basada en **máximos locales** de
-la **probabilidad por clase** (clasificación) o del **valor predicho** (regresión).
+[Versión en español](README.es.md)
+
+Edge segmentation and hyperboundary exploration based on **local maxima** of the **class probability** (classification) or the **predicted value** (regression).
 
 ---
 
-## Instalación
+## Installation
 
-Requiere **Python >=3.9** y se recomienda el uso de un entorno virtual.
+Requires **Python >=3.9** and it is recommended to use a virtual environment.
 
 ```bash
 pip install -e .
 ```
 
-Dependencias base: `numpy`, `pandas`, `scikit-learn>=1.1`, `matplotlib`
+Base dependencies: `numpy`, `pandas`, `scikit-learn>=1.1`, `matplotlib`
 
-Para un entorno de desarrollo con pruebas:
+For a development environment with tests:
 
 ```bash
 pip install -e ".[dev]"
@@ -25,60 +26,60 @@ PYTHONPATH=src pytest -q
 
 ---
 
-## API rápida
+## Quick API
 
 ```python
 from sheshe import ModalBoundaryClustering
 
-# clasificación
+# classification
 clf = ModalBoundaryClustering(
-    base_estimator=None,           # por defecto LogisticRegression
+    base_estimator=None,           # defaults to LogisticRegression
     task="classification",         # "classification" | "regression"
-    base_2d_rays=8,                # nº de rayos en 2D (≈45°)
+    base_2d_rays=8,                # number of rays in 2D (≈45°)
     direction="center_out",        # "center_out" | "outside_in"
     scan_radius_factor=3.0,
     scan_steps=64,
     random_state=0
 )
 
-# regresión (ejemplo)
+# regression (example)
 reg = ModalBoundaryClustering(task="regression")
 ```
 
-### Métodos
+### Methods
 - `fit(X, y)`
 - `predict(X)`
-- `predict_proba(X)`  → clasificación: probas por clase; regresión: valor normalizado [0,1]
-- `interpretability_summary(feature_names=None)` → DataFrame con:
+- `predict_proba(X)`  → classification: class probabilities; regression: normalized value [0,1]
+- `interpretability_summary(feature_names=None)` → DataFrame whose columns are in Spanish:
   - `Tipo`: "centroide" | "inflexion_point"
-  - `Distancia`: radio desde el centro al punto de inflexión
-  - `Categoria`: clase (o "NA" en regresión)
-  - `pendiente`: df/dt en el punto de inflexión
+  - `Distancia`: radius from the center to the inflection point
+  - `Categoria`: class (or "NA" in regression)
+  - `pendiente`: df/dt at the inflection point
   - `valor_real` / `valor_norm`
-  - `coord_0..coord_{d-1}` o nombres de features
-- `plot_pairs(X, y=None, max_pairs=None)` → gráficos 2D para todas las combinaciones de pares
-- `save(filepath)` → guarda el modelo mediante `joblib`
-- `ModalBoundaryClustering.load(filepath)` → carga una instancia guardada
+  - `coord_0..coord_{d-1}` or feature names
+- `plot_pairs(X, y=None, max_pairs=None)` → 2D plots for all pairwise combinations
+- `save(filepath)` → save the model using `joblib`
+- `ModalBoundaryClustering.load(filepath)` → load a saved instance
 
 ---
 
-## ¿Cómo funciona?
-1. Entrena/usa un **modelo base** de sklearn (clasificación con `predict_proba` o regresión con `predict`).
-2. Busca **máximos locales** por **ascenso de gradiente** con barreras en los límites del dominio.
-3. Desde el máximo, traza **rayos** (direcciones) en la hiperesfera:
-   - 2D: 8 rayos por defecto
-   - 3D: ~26 direcciones (cobertura por *caps* esféricos con muestreo Fibonacci)
-   - >3D: mezcla de unas pocas direcciones globales + **subespacios** 2D/3D
-4. Sobre cada rayo, **escanea radialmente** y calcula el **primer punto de inflexión** según `direction`:
-   - `center_out`: desde el centro hacia fuera
-   - `outside_in`: desde el exterior hacia el centro
-   Registra además la **pendiente** (df/dt) en ese punto.
-5. Conecta los puntos de inflexión para formar la **frontera** de la región de alta probabilidad/valor.
+## How does it work?
+1. Trains/uses a **base model** from sklearn (classification with `predict_proba` or regression with `predict`).
+2. Searches for **local maxima** via **gradient ascent** with barriers at the domain limits.
+3. From the maximum, traces **rays** (directions) on the hypersphere:
+   - 2D: 8 rays by default
+   - 3D: ~26 directions (coverage by spherical *caps* using Fibonacci sampling)
+   - >3D: mix of a few global directions + **2D/3D subspaces**
+4. Along each ray, **scans radially** and computes the **first inflection point** according to `direction`:
+   - `center_out`: from the center outward
+   - `outside_in`: from the exterior toward the center
+   It also records the **slope** (df/dt) at that point.
+5. Connects the inflection points to form the **boundary** of the high probability/value region.
 
 ---
 
-## Ejemplos
-### Clasificación — Iris
+## Examples
+### Classification — Iris
 ```python
 import matplotlib.pyplot as plt
 from sklearn.datasets import load_iris
@@ -96,11 +97,11 @@ sh = ModalBoundaryClustering(
 ).fit(X, y)
 
 print(sh.interpretability_summary(iris.feature_names).head())
-sh.plot_pairs(X, y, max_pairs=3)   # genera las gráficas
+sh.plot_pairs(X, y, max_pairs=3)   # generate plots
 plt.show()
 ```
 
-### Clasificación con modelo ya entrenado
+### Classification with a pre-trained model
 ```python
 import matplotlib.pyplot as plt
 from sklearn.datasets import load_wine
@@ -110,11 +111,11 @@ from sheshe import ModalBoundaryClustering
 wine = load_wine()
 X, y = wine.data, wine.target
 
-# Entrena un modelo de forma independiente
+# Train a model separately
 base_model = RandomForestClassifier(n_estimators=200, random_state=0)
 base_model.fit(X, y)
 
-# Usa SheShe con ese modelo ya ajustado
+# Use SheShe with that fitted model
 sh = ModalBoundaryClustering(
     base_estimator=base_model,
     task="classification",
@@ -126,7 +127,7 @@ sh.plot_pairs(X, y, max_pairs=2)
 plt.show()
 ```
 
-### Regresión — Diabetes
+### Regression — Diabetes
 ```python
 import matplotlib.pyplot as plt
 from sklearn.datasets import load_diabetes
@@ -148,13 +149,13 @@ sh.plot_pairs(X, max_pairs=3)
 plt.show()
 ```
 
-### Guardado de gráficas
+### Saving plots
 ```python
 from pathlib import Path
 import matplotlib.pyplot as plt
 
-# tras llamar a ``sh.plot_pairs(...)``
-out_dir = Path("imagenes")
+# after calling ``sh.plot_pairs(...)``
+out_dir = Path("images")
 out_dir.mkdir(exist_ok=True)
 for i, fig_num in enumerate(plt.get_fignums()):
     plt.figure(fig_num)
@@ -162,7 +163,7 @@ for i, fig_num in enumerate(plt.get_fignums()):
     plt.close(fig_num)
 ```
 
-### Guardar y cargar modelo
+### Save and load model
 ```python
 from pathlib import Path
 from sklearn.datasets import load_iris
@@ -172,62 +173,57 @@ iris = load_iris()
 X, y = iris.data, iris.target
 
 sh = ModalBoundaryClustering().fit(X, y)
-ruta = Path("sheshe_model.joblib")
-sh.save(ruta)
-sh2 = ModalBoundaryClustering.load(ruta)
+path = Path("sheshe_model.joblib")
+sh.save(path)
+sh2 = ModalBoundaryClustering.load(path)
 print((sh.predict(X) == sh2.predict(X)).all())
 ```
 
-Para ejemplos más completos, consulta la carpeta `examples/`.
+For more complete examples, see the `examples/` folder.
 
-### Experimentos y benchmark
+### Experiments and benchmark
 
-Los experimentos de comparación con algoritmos **no supervisados** se encuentran
-en la carpeta [`experiments/`](experiments/). El script
-[`compare_unsupervised.py`](experiments/compare_unsupervised.py) evalúa cinco
-conjuntos de datos distintos, explora parámetros de **SheShe**, **KMeans** y
-**DBSCAN**, y almacena cuatro métricas (`ARI`, `homogeneity`, `completeness`,
-`v_measure`) junto con el tiempo de ejecución (`runtime_sec`).
+Comparisons with **unsupervised** algorithms are located in the [`experiments/`](experiments/) folder. The script [`compare_unsupervised.py`](experiments/compare_unsupervised.py) evaluates five different datasets, explores parameters of **SheShe**, **KMeans**, and **DBSCAN**, and stores four metrics (`ARI`, `homogeneity`, `completeness`, `v_measure`) along with the execution time (`runtime_sec`).
 
 ```bash
 python experiments/compare_unsupervised.py
 cat benchmark/unsupervised_results.csv | head
 ```
 
-se generan los resultados dentro de `benchmark/`.
+The results are generated inside `benchmark/`.
 
 ---
 
-## Parámetros clave
-- `base_2d_rays` → controla la resolución angular en 2D (8 por defecto). 3D escala ~26; d>3 usa subespacios.
-- `direction` → "center_out" | "outside_in" para localizar el punto de inflexión.
-- `scan_radius_factor`, `scan_steps` → tamaño y resolución del escaneo radial.
-- `grad_*` → hiperparámetros del ascenso (tasa, iteraciones, tolerancias).
-- `max_subspaces` → nº máx. de subespacios considerados cuando d>3.
+## Key parameters
+- `base_2d_rays` → controls angular resolution in 2D (8 by default). 3D scales to ~26; d>3 uses subspaces.
+- `direction` → "center_out" | "outside_in" to locate the inflection point.
+- `scan_radius_factor`, `scan_steps` → size and resolution of the radial scan.
+- `grad_*` → ascent hyperparameters (rate, iterations, tolerances).
+- `max_subspaces` → maximum number of subspaces considered when d>3.
 
 ---
 
-## Limitaciones
-- Depende de la **superficie** producida por el modelo base (puede ser rugosa en RF).
-- En alta dimensión, la frontera es una **aproximación** (subespacios).
-- Encuentra **máximos locales** (no garantiza el global), mitigado con múltiples *seeds*.
+## Limitations
+- Depends on the **surface** produced by the base model (may be rough in RF).
+- In high dimension, the boundary is an **approximation** (subspaces).
+- Finds **local maxima** (does not guarantee the global one), mitigated with multiple seeds.
 
 ---
 
-## Contribuir
+## Contributing
 
-Las mejoras son bienvenidas. Para proponer cambios:
+Improvements are welcome. To propose changes:
 
-1. Haz un *fork* del repositorio y crea una rama descriptiva.
-2. Instala las dependencias de desarrollo y ejecuta los tests:
+1. Fork the repository and create a descriptive branch.
+2. Install the development dependencies and run tests:
 
    ```bash
    pip install -e ".[dev]"
    PYTHONPATH=src pytest -q
    ```
-3. Envía un *pull request* con una descripción clara del cambio.
+3. Submit a pull request with a clear description of the change.
 
 ---
 
-## Licencia
+## License
 MIT

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 [Versión en español](README.es.md)
 
-Edge segmentation and hyperboundary exploration based on **local maxima** of the **class probability** (classification) or the **predicted value** (regression).
+Edge segmentation and hyperboundary exploration based on **local maxima** of the
+**class probability** (classification) or the **predicted value** (regression).
 
 ---
 

--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -30,19 +30,19 @@ def _rng(random_state: Optional[int]) -> np.random.RandomState:
     return np.random.RandomState(None if random_state is None else int(random_state))
 
 def sample_unit_directions_gaussian(n: int, dim: int, random_state: Optional[int] = 42) -> np.ndarray:
-    """Direcciones ~uniformes en S^{dim-1} normalizando gaussianas."""
+    """~Uniform directions on S^{dim-1} by normalizing Gaussians."""
     rng = _rng(random_state)
     U = rng.normal(size=(n, dim))
     U /= (np.linalg.norm(U, axis=1, keepdims=True) + 1e-12)
     return U
 
 def sample_unit_directions_circle(n: int) -> np.ndarray:
-    """2D: n ángulos equiespaciados."""
+    """2D: n evenly spaced angles."""
     ang = np.linspace(0, 2*np.pi, n, endpoint=False)
     return np.column_stack([np.cos(ang), np.sin(ang)])
 
 def sample_unit_directions_sph_fibo(n: int) -> np.ndarray:
-    """3D: puntos casi equi-área en S^2 (Fibonacci esférico)."""
+    """3D: near equal-area points on S^2 (spherical Fibonacci)."""
     ga = (1 + 5 ** 0.5) / 2  # golden ratio
     k = np.arange(n)
     z = 1 - (2*k + 1)/n
@@ -53,7 +53,7 @@ def sample_unit_directions_sph_fibo(n: int) -> np.ndarray:
     return np.column_stack([x, y, z])
 
 def finite_diff_gradient(f, x: np.ndarray, eps: float = 1e-2) -> np.ndarray:
-    """Gradiente por diferencia central."""
+    """Gradient using central differences."""
     d = x.shape[0]
     g = np.zeros(d, dtype=float)
     for i in range(d):
@@ -63,8 +63,8 @@ def finite_diff_gradient(f, x: np.ndarray, eps: float = 1e-2) -> np.ndarray:
 
 def project_step_with_barrier(x: np.ndarray, g: np.ndarray, lo: np.ndarray, hi: np.ndarray) -> np.ndarray:
     """
-    Anula componentes del gradiente que empujan fuera del dominio cuando estamos en el borde.
-    Evita 'escaparse' y fuerza el movimiento por otras variables.
+    Zero out gradient components that push outside the domain when at the boundary.
+    Prevents 'escaping' and forces movement through other variables.
     """
     step = g.copy()
     for i in range(len(x)):
@@ -76,7 +76,7 @@ def gradient_ascent(
     f, x0: np.ndarray, bounds: Tuple[np.ndarray, np.ndarray],
     lr: float = 0.1, max_iter: int = 200, tol: float = 1e-5, eps_grad: float = 1e-2
 ) -> np.ndarray:
-    """Ascenso con backtracking y barreras en los límites."""
+    """Gradient ascent with backtracking and boundary barriers."""
     lo, hi = bounds
     x = x0.copy()
     best = f(x)
@@ -109,12 +109,12 @@ def second_diff(arr: np.ndarray) -> np.ndarray:
 
 def find_inflection(ts: np.ndarray, vals: np.ndarray, direction: str) -> Tuple[float, float]:
     """
-    Devuelve (t_inf, slope_at_inf). direction: 'center_out' | 'outside_in'.
-    - t_inf: parámetro t en [0,T]
-    - slope_at_inf: df/dt en t_inf (signo coherente con t creciente).
+    Return (t_inf, slope_at_inf). direction: 'center_out' | 'outside_in'.
+    - t_inf: parameter t in [0, T]
+    - slope_at_inf: df/dt at t_inf (sign consistent with increasing t).
     """
     if direction not in ("center_out", "outside_in"):
-        raise ValueError("direction debe ser 'center_out' u 'outside_in'.")
+        raise ValueError("direction must be 'center_out' or 'outside_in'.")
 
     # Prepara serie según dirección
     if direction == "outside_in":
@@ -190,10 +190,10 @@ class ClusterRegion:
 
 def rays_count_auto(dim: int, base_2d: int = 8) -> int:
     """
-    Nº de rays sugerido según dimensión:
-      - 2D: base_2d (por defecto 8)
-      - 3D: N ≈ 2 / (1 - cos(π/base_2d))  (cobertura por caps; ~26 si base_2d=8)
-      - >3D: mantener coste acotado: usamos subespacios → devolver pequeño nº global.
+    Suggested number of rays according to dimension:
+      - 2D: base_2d (default 8)
+      - 3D: N ≈ 2 / (1 - cos(π/base_2d)) (cap coverage; ~26 if base_2d=8)
+      - >3D: keep cost bounded: use subspaces → return a small global count.
     """
     if dim <= 1:
         return 1
@@ -209,12 +209,12 @@ def rays_count_auto(dim: int, base_2d: int = 8) -> int:
 def generate_directions(dim: int, base_2d: int, random_state: Optional[int] = 42,
                         max_subspaces: int = 20) -> np.ndarray:
     """
-    Conjunto de direcciones:
-      - 2D: 8 equiángulos (por defecto)
-      - 3D: ~N por fórmula de caps + Fibonacci esférico
-      - >3D: mezcla de:
-          * pequeños globales (gaussianos) y
-          * direcciones embebidas en subespacios 2D/3D (todas o muestreadas)
+    Set of directions:
+      - 2D: 8 equally spaced (default)
+      - 3D: ~N by cap formula + spherical Fibonacci
+      - >3D: mix of:
+          * a few global (Gaussian) directions and
+          * directions embedded in 2D/3D subspaces (all or sampled)
     """
     if dim == 1:
         return np.array([[1.0]])
@@ -271,14 +271,14 @@ class ModalBoundaryClustering(BaseEstimator):
     """
     SheShe: Smart High-dimensional Edge Segmentation & Hyperboundary Explorer
 
-    Clusterización por máximos locales sobre la superficie de probabilidad (clasificación)
-    o del valor predicho (regresión). Compatible con sklearn.
+    Clustering by local maxima on the probability surface (classification)
+    or the predicted value (regression). Compatible with sklearn.
 
-    Novedades v2:
-      - Nº de rays dinámico: 2D→8; 3D≈26; >3D se reduce con subespacios (2D/3D) + pocos globales.
-      - `direction`: 'center_out' (default) o 'outside_in' para localizar la inflexión.
-      - Pendiente en punto de inflexión (df/dt).
-      - Ascenso con barreras en bordes.
+    What's new in v2:
+      - Dynamic number of rays: 2D→8; 3D≈26; >3D reduced via subspaces (2D/3D) plus few global ones.
+      - `direction`: 'center_out' (default) or 'outside_in' to locate the inflection.
+      - Slope at the inflection point (df/dt).
+      - Ascent with boundary barriers.
     """
 
     def __init__(
@@ -340,7 +340,7 @@ class ModalBoundaryClustering(BaseEstimator):
         Xs = self.scaler_.transform(X)
         if self.task == "classification":
             if class_idx is None:
-                raise ValueError("class_idx requerido en clasificación.")
+                raise ValueError("class_idx required for classification.")
             proba = self.estimator_.predict_proba(Xs)
             return proba[:, class_idx]
         else:
@@ -381,8 +381,8 @@ class ModalBoundaryClustering(BaseEstimator):
     def _scan_radii(self, center: np.ndarray, f, directions: np.ndarray, X_std: np.ndarray
                    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
-        Para cada dirección u: escaneo radial t∈[0,T] y primer punto de inflexión según `direction`.
-        Devuelve (radii, points, slopes).
+        For each direction ``u``: radial scan ``t∈[0,T]`` and first inflection point according to ``direction``.
+        Returns ``(radii, points, slopes)``.
         """
         d = center.shape[0]
         T = float(self.scan_radius_factor * np.linalg.norm(X_std))
@@ -477,10 +477,10 @@ class ModalBoundaryClustering(BaseEstimator):
         return self
 
     def fit_predict(self, X: Union[np.ndarray, pd.DataFrame], y: Optional[np.ndarray] = None) -> np.ndarray:
-        """Ajusta el modelo y devuelve la predicción para ``X``.
+        """Fit the model and return the prediction for ``X``.
 
-        Atajo común en *sklearn* que equivale a llamar a :meth:`fit` y
-        posteriormente a :meth:`predict` sobre los mismos datos.
+        Common *sklearn* shortcut equivalent to calling :meth:`fit`
+        followed by :meth:`predict` on the same data.
         """
         self.fit(X, y)
         return self.predict(X)
@@ -537,7 +537,7 @@ class ModalBoundaryClustering(BaseEstimator):
         return result
 
     def predict_proba(self, X: Union[np.ndarray, pd.DataFrame]) -> np.ndarray:
-        """Clasificación: proba por clase del estimador base. Regresión: valor normalizado [0,1]."""
+        """Classification: class probabilities from the base estimator. Regression: normalized value [0,1]."""
         start = time.perf_counter()
         try:
             check_is_fitted(self, "regions_")
@@ -558,26 +558,25 @@ class ModalBoundaryClustering(BaseEstimator):
         return result
 
     def decision_function(self, X: Union[np.ndarray, pd.DataFrame]) -> np.ndarray:
-        """Valores de decisión del estimador base con *fallback* automático.
+        """Decision values from the base estimator with automatic fallback.
 
-        Si el estimador subyacente dispone de :meth:`decision_function`, se
-        devuelve dicha salida. En caso contrario se recurre a
-        :meth:`predict_proba` para tareas de clasificación o a
-        :meth:`predict` para regresión.
+        If the underlying estimator implements :meth:`decision_function`, that
+        output is returned. Otherwise it falls back to :meth:`predict_proba`
+        for classification or :meth:`predict` for regression.
 
         Parameters
         ----------
         X:
-            Muestras a evaluar.
+            Samples to evaluate.
 
         Returns
         -------
         ndarray
-            Puntajes, probabilidades o predicciones dependiendo del *fallback*.
+            Scores, probabilities or predictions depending on the fallback.
 
         Examples
         --------
-        Clasificación con un estimador que implementa ``decision_function``::
+        Classification with an estimator that implements ``decision_function``::
 
             >>> from sklearn.datasets import load_iris
             >>> from sklearn.linear_model import LogisticRegression
@@ -587,7 +586,7 @@ class ModalBoundaryClustering(BaseEstimator):
             >>> sh.decision_function(X[:2]).shape
             (2, 3)
 
-        Clasificación con un modelo sin ``decision_function`` (usa
+        Classification with a model without ``decision_function`` (uses
         ``predict_proba``)::
 
             >>> from sklearn.ensemble import RandomForestClassifier
@@ -596,7 +595,7 @@ class ModalBoundaryClustering(BaseEstimator):
             >>> sh.decision_function(X[:2]).shape
             (2, 3)
 
-        En regresión la salida proviene de ``predict``::
+        In regression the output comes from ``predict``::
 
             >>> from sklearn.datasets import make_regression
             >>> from sklearn.ensemble import RandomForestRegressor
@@ -626,20 +625,43 @@ class ModalBoundaryClustering(BaseEstimator):
         return result
 
     def score(self, X: Union[np.ndarray, pd.DataFrame], y: np.ndarray) -> float:
-        """Devuelve la métrica de sklearn delegando en el pipeline interno."""
+        """Return the sklearn metric delegating to the internal pipeline."""
         check_is_fitted(self, "pipeline_")
         return self.pipeline_.score(np.asarray(X, dtype=float), y)
 
     def save(self, filepath: Union[str, Path]) -> None:
-        """Guarda la instancia actual en ``filepath`` usando ``joblib.dump``."""
+        """Save the current instance to ``filepath`` using ``joblib.dump``."""
         joblib.dump(self, filepath)
 
     @classmethod
     def load(cls, filepath: Union[str, Path]) -> "ModalBoundaryClustering":
-        """Carga una instancia previamente guardada con :meth:`save`."""
+        """Load an instance previously saved with :meth:`save`."""
         return joblib.load(filepath)
 
     def interpretability_summary(self, feature_names: Optional[List[str]] = None) -> pd.DataFrame:
+        """Return a DataFrame summarizing centers and inflection points.
+
+        The resulting DataFrame uses Spanish column names:
+
+        - ``Tipo``: "centroide" or "inflexion_point"
+        - ``Distancia``: radius from the center to the inflection point
+        - ``Categoria``: class label (or "NA" in regression)
+        - ``pendiente``: df/dt at the inflection point
+        - ``valor_real`` / ``valor_norm``: raw and normalized model output
+        - coordinate columns: either provided ``feature_names`` or ``coord_{i}``
+          defaults
+
+        Parameters
+        ----------
+        feature_names:
+            Names for the coordinate columns. Defaults to the internal feature
+            names discovered during :meth:`fit`.
+
+        Returns
+        -------
+        DataFrame
+            Summary with one row for the centroid and one per inflection point.
+        """
         check_is_fitted(self, "regions_")
         d = self.n_features_in_
         if feature_names is None:
@@ -758,7 +780,7 @@ class ModalBoundaryClustering(BaseEstimator):
 
     def plot_pairs(self, X: Union[np.ndarray, pd.DataFrame], y: Optional[np.ndarray] = None,
                    max_pairs: Optional[int] = None):
-        """Genera figuras para todas las combinaciones 2D (o hasta max_pairs)."""
+        """Generate figures for all 2D combinations (or up to max_pairs)."""
         check_is_fitted(self, "regions_")
         X = np.asarray(X, dtype=float)
         d = X.shape[1]
@@ -767,7 +789,7 @@ class ModalBoundaryClustering(BaseEstimator):
             pairs = pairs[:max_pairs]
 
         if self.task == "classification":
-            assert y is not None, "y requerido para graficar clasificación."
+            assert y is not None, "y required to plot classification."
             palette = ["#e41a1c", "#377eb8", "#4daf4a", "#984ea3",
                        "#ff7f00", "#a65628", "#f781bf", "#999999"]
             class_colors = {c: palette[i % len(palette)] for i, c in enumerate(self.classes_)}


### PR DESCRIPTION
## Summary
- Use English README as default and add Spanish translation `README.es.md`
- Clarify `interpretability_summary` output and document Spanish column names
- Include Spanish README in the package manifest

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ae1218214832cae0a66c7ae7367b7