### PR TITLE
Validate y length in plot_pairs

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -907,6 +907,7 @@ class ModalBoundaryClustering(BaseEstimator):
 
         if self.task == "classification":
             assert y is not None, "y requerido para graficar clasificación."
+            assert len(y) == len(X), "X e y deben tener la misma longitud."
             palette = ["#e41a1c", "#377eb8", "#4daf4a", "#984ea3",
                        "#ff7f00", "#a65628", "#f781bf", "#999999"]
             class_colors = {c: palette[i % len(palette)] for i, c in enumerate(self.classes_)}

--- a/tests/test_plot_pairs.py
+++ b/tests/test_plot_pairs.py
@@ -1,0 +1,10 @@
+import pytest
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+
+def test_plot_pairs_mismatched_y_length():
+    X, y = load_iris(return_X_y=True)
+    sh = ModalBoundaryClustering(random_state=0).fit(X, y)
+    with pytest.raises(AssertionError, match="misma longitud"):
+        sh.plot_pairs(X, y[:-1])


### PR DESCRIPTION
## Summary
- ensure `plot_pairs` checks that classification labels match the number of samples
- add regression test for mis-matched `y` length

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b8f80bc60832c958a4f067f7278aa