### PR TITLE
Validate n_max_seeds and handle empty seeds

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -302,6 +302,8 @@ class ModalBoundaryClustering(BaseEstimator):
     ):
         if scan_steps < 2:
             raise ValueError("scan_steps must be at least 2")
+        if n_max_seeds < 1:
+            raise ValueError("n_max_seeds must be at least 1")
 
         self.base_estimator = base_estimator
         self.task = task
@@ -367,6 +369,8 @@ class ModalBoundaryClustering(BaseEstimator):
 
     def _find_maximum(self, X: np.ndarray, f, bounds: Tuple[np.ndarray, np.ndarray]) -> np.ndarray:
         seeds = self._choose_seeds(X, f, min(self.n_max_seeds, len(X)))
+        if len(seeds) == 0:
+            return X[0]
         best_x, best_v = seeds[0].copy(), f(seeds[0])
         for s in seeds:
             x_star = gradient_ascent(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -105,3 +105,8 @@ def test_membership_matrix_no_directions():
     sh.fit(X, y)
     with pytest.raises(ValueError, match="direcciones"):
         sh.predict(X)
+
+
+def test_n_max_seeds_minimum():
+    with pytest.raises(ValueError, match="n_max_seeds"):
+        ModalBoundaryClustering(n_max_seeds=0)


### PR DESCRIPTION
## Summary
- ensure `n_max_seeds` is at least 1 in `ModalBoundaryClustering`
- fallback to first sample when no seeds are available
- add regression test for `n_max_seeds=0`

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b8fce18b0832c92b6d85885b5b6b2