### PR TITLE
Validate base_2d_rays parameter

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -279,6 +279,11 @@ class ModalBoundaryClustering(BaseEstimator):
       - `direction`: 'center_out' (default) o 'outside_in' para localizar la inflexión.
       - Pendiente en punto de inflexión (df/dt).
       - Ascenso con barreras en bordes.
+
+    Parameters
+    ----------
+    base_2d_rays : int, default=8
+        Número de rayos en 2D (≈45°). Debe ser mayor que cero.
     """
 
     def __init__(
@@ -302,6 +307,8 @@ class ModalBoundaryClustering(BaseEstimator):
     ):
         if scan_steps < 2:
             raise ValueError("scan_steps must be at least 2")
+        if base_2d_rays <= 0:
+            raise ValueError("base_2d_rays must be greater than 0")
 
         self.base_estimator = base_estimator
         self.task = task

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -92,16 +92,6 @@ def test_scan_steps_minimum():
     with pytest.raises(ValueError):
         ModalBoundaryClustering(scan_steps=1)
 
-
-def test_membership_matrix_no_directions():
-    iris = load_iris()
-    X, y = iris.data[:, :2], iris.target
-    sh = ModalBoundaryClustering(
-        base_estimator=LogisticRegression(max_iter=200),
-        task="classification",
-        base_2d_rays=0,
-        random_state=0,
-    )
-    sh.fit(X, y)
-    with pytest.raises(ValueError, match="direcciones"):
-        sh.predict(X)
+def test_base_2d_rays_must_be_positive():
+    with pytest.raises(ValueError, match="base_2d_rays"):
+        ModalBoundaryClustering(base_2d_rays=0)


### PR DESCRIPTION
## Summary
- ensure `base_2d_rays` is positive during `ModalBoundaryClustering` initialization
- document the positivity requirement for `base_2d_rays`
- add unit test covering invalid `base_2d_rays` values

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b91fcf3b4832ca3c7dd5621fbdfdb