### PR TITLE
Handle empty region directions in membership matrix

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import joblib
+import warnings
 
 from sklearn.base import BaseEstimator, clone
 from sklearn.preprocessing import StandardScaler
@@ -516,9 +517,11 @@ class ModalBoundaryClustering(BaseEstimator):
         R = np.zeros((n, len(self.regions_)), dtype=int)
         for k, reg in enumerate(self.regions_):
             if reg.directions.size == 0:
-                raise ValueError(
-                    "Region con número de direcciones cero; revise base_2d_rays"
+                warnings.warn(
+                    "Región sin direcciones; se marca como fuera de la región",
+                    RuntimeWarning,
                 )
+                continue
             c = reg.center
             V = X - c
             norms = np.linalg.norm(V, axis=1) + 1e-12

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -103,8 +103,12 @@ def test_membership_matrix_no_directions():
         random_state=0,
     )
     sh.fit(X, y)
-    with pytest.raises(ValueError, match="direcciones"):
-        sh.predict(X)
+    M = sh._membership_matrix(X)
+    assert M.shape == (X.shape[0], len(sh.regions_))
+    assert np.all(M == 0)
+    base_pred = sh.pipeline_.predict(X)
+    pred = sh.predict(X)
+    assert np.all(pred == base_pred)
 
 
 def test_n_max_seeds_minimum():


### PR DESCRIPTION
## Summary
- Avoid errors when a region has no directions by warning and treating points as outside the region
- Add regression test using `base_2d_rays=0` ensuring membership matrix returns all zeros and predictions fall back to the base estimator

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b9436ae48832c8a887e4994dac197