### PR TITLE
Translate documentation and docstrings to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
-# SheShe  
+# SheShe
 **Smart High-dimensional Edge Segmentation & Hyperboundary Explorer**
 
-Segmentación de bordes y exploración de hiper-fronteras basada en **máximos locales** de
-la **probabilidad por clase** (clasificación) o del **valor predicho** (regresión).
+Edge segmentation and hyperboundary exploration based on **local maxima** of
+the **class probability** (classification) or the **predicted value**
+(regression).
 
 ---
 
-## Instalación
+## Installation
 
-Requiere **Python >=3.9** y se recomienda el uso de un entorno virtual.
+Requires **Python >=3.9** and it is recommended to work inside a virtual
+environment.
 
 ```bash
 pip install -e .
 ```
 
-Dependencias base: `numpy`, `pandas`, `scikit-learn>=1.1`, `matplotlib`
+Base dependencies: `numpy`, `pandas`, `scikit-learn>=1.1`, `matplotlib`
 
-Para un entorno de desarrollo con pruebas:
+For a development environment with tests:
 
 ```bash
 pip install -e ".[dev]"
@@ -25,60 +27,64 @@ PYTHONPATH=src pytest -q
 
 ---
 
-## API rápida
+## Quick API
 
 ```python
 from sheshe import ModalBoundaryClustering
 
-# clasificación
+# classification
 clf = ModalBoundaryClustering(
-    base_estimator=None,           # por defecto LogisticRegression
+    base_estimator=None,           # default LogisticRegression
     task="classification",         # "classification" | "regression"
-    base_2d_rays=8,                # nº de rayos en 2D (≈45°)
+    base_2d_rays=8,                # number of rays in 2D (≈45°)
     direction="center_out",        # "center_out" | "outside_in"
     scan_radius_factor=3.0,
     scan_steps=64,
     random_state=0
 )
 
-# regresión (ejemplo)
+# regression (example)
 reg = ModalBoundaryClustering(task="regression")
 ```
 
-### Métodos
+### Methods
 - `fit(X, y)`
 - `predict(X)`
-- `predict_proba(X)`  → clasificación: probas por clase; regresión: valor normalizado [0,1]
-- `interpretability_summary(feature_names=None)` → DataFrame con:
-  - `Tipo`: "centroide" | "inflexion_point"
-  - `Distancia`: radio desde el centro al punto de inflexión
-  - `Categoria`: clase (o "NA" en regresión)
-  - `pendiente`: df/dt en el punto de inflexión
-  - `valor_real` / `valor_norm`
-  - `coord_0..coord_{d-1}` o nombres de features
-- `plot_pairs(X, y=None, max_pairs=None)` → gráficos 2D para todas las combinaciones de pares
-- `save(filepath)` → guarda el modelo mediante `joblib`
-- `ModalBoundaryClustering.load(filepath)` → carga una instancia guardada
+- `predict_proba(X)`  → classification: per-class probabilities; regression: normalized value [0,1]
+- `interpretability_summary(feature_names=None)` → DataFrame with:
+  - `Type`: "centroid" | "inflection_point"
+  - `Distance`: radius from the center to the inflection point
+  - `Category`: class (or "NA" in regression)
+  - `slope`: df/dt at the inflection point
+  - `real_value` / `norm_value`
+  - `coord_0..coord_{d-1}` or feature names
+- `plot_pairs(X, y=None, max_pairs=None)` → 2D plots for all pair combinations
+- `save(filepath)` → save the model using `joblib`
+- `ModalBoundaryClustering.load(filepath)` → load a saved instance
 
 ---
 
-## ¿Cómo funciona?
-1. Entrena/usa un **modelo base** de sklearn (clasificación con `predict_proba` o regresión con `predict`).
-2. Busca **máximos locales** por **ascenso de gradiente** con barreras en los límites del dominio.
-3. Desde el máximo, traza **rayos** (direcciones) en la hiperesfera:
-   - 2D: 8 rayos por defecto
-   - 3D: ~26 direcciones (cobertura por *caps* esféricos con muestreo Fibonacci)
-   - >3D: mezcla de unas pocas direcciones globales + **subespacios** 2D/3D
-4. Sobre cada rayo, **escanea radialmente** y calcula el **primer punto de inflexión** según `direction`:
-   - `center_out`: desde el centro hacia fuera
-   - `outside_in`: desde el exterior hacia el centro
-   Registra además la **pendiente** (df/dt) en ese punto.
-5. Conecta los puntos de inflexión para formar la **frontera** de la región de alta probabilidad/valor.
+## How does it work?
+1. Train/use a **base model** from sklearn (classification with `predict_proba`
+   or regression with `predict`).
+2. Find **local maxima** via **gradient ascent** with barriers at the domain
+   boundaries.
+3. From the maximum, trace **rays** (directions) on the hypersphere:
+   - 2D: 8 rays by default
+   - 3D: ~26 directions (coverage by spherical *caps* using Fibonacci sampling)
+   - >3D: mixture of a few global directions + 2D/3D **subspaces**
+4. Along each ray, **scan radially** and compute the **first inflection point**
+   according to `direction`:
+   - `center_out`: from the center outward
+   - `outside_in`: from the outside toward the center
+   Also record the **slope** (df/dt) at that point.
+5. Connect the inflection points to form the **boundary** of the region with
+   high probability/value.
 
 ---
 
-## Ejemplos
-### Clasificación — Iris
+## Examples
+### Classification — Iris
 ```python
 import matplotlib.pyplot as plt
 from sklearn.datasets import load_iris
@@ -96,11 +102,11 @@ sh = ModalBoundaryClustering(
 ).fit(X, y)
 
 print(sh.interpretability_summary(iris.feature_names).head())
-sh.plot_pairs(X, y, max_pairs=3)   # genera las gráficas
+sh.plot_pairs(X, y, max_pairs=3)   # generate the plots
 plt.show()
 ```
 
-### Clasificación con modelo ya entrenado
+### Classification with pre-trained model
 ```python
 import matplotlib.pyplot as plt
 from sklearn.datasets import load_wine
@@ -110,11 +116,11 @@ from sheshe import ModalBoundaryClustering
 wine = load_wine()
 X, y = wine.data, wine.target
 
-# Entrena un modelo de forma independiente
+# Train a model independently
 base_model = RandomForestClassifier(n_estimators=200, random_state=0)
 base_model.fit(X, y)
 
-# Usa SheShe con ese modelo ya ajustado
+# Use SheShe with that pre-fitted model
 sh = ModalBoundaryClustering(
     base_estimator=base_model,
     task="classification",
@@ -126,7 +132,7 @@ sh.plot_pairs(X, y, max_pairs=2)
 plt.show()
 ```
 
-### Regresión — Diabetes
+### Regression — Diabetes
 ```python
 import matplotlib.pyplot as plt
 from sklearn.datasets import load_diabetes
@@ -148,13 +154,13 @@ sh.plot_pairs(X, max_pairs=3)
 plt.show()
 ```
 
-### Guardado de gráficas
+### Saving figures
 ```python
 from pathlib import Path
 import matplotlib.pyplot as plt
 
-# tras llamar a ``sh.plot_pairs(...)``
-out_dir = Path("imagenes")
+# after calling ``sh.plot_pairs(...)``
+out_dir = Path("images")
 out_dir.mkdir(exist_ok=True)
 for i, fig_num in enumerate(plt.get_fignums()):
     plt.figure(fig_num)
@@ -162,7 +168,7 @@ for i, fig_num in enumerate(plt.get_fignums()):
     plt.close(fig_num)
 ```
 
-### Guardar y cargar modelo
+### Save and load model
 ```python
 from pathlib import Path
 from sklearn.datasets import load_iris
@@ -172,62 +178,65 @@ iris = load_iris()
 X, y = iris.data, iris.target
 
 sh = ModalBoundaryClustering().fit(X, y)
-ruta = Path("sheshe_model.joblib")
-sh.save(ruta)
-sh2 = ModalBoundaryClustering.load(ruta)
+path = Path("sheshe_model.joblib")
+sh.save(path)
+sh2 = ModalBoundaryClustering.load(path)
 print((sh.predict(X) == sh2.predict(X)).all())
 ```
 
-Para ejemplos más completos, consulta la carpeta `examples/`.
+For more complete examples, see the `examples/` folder.
 
-### Experimentos y benchmark
+### Experiments and benchmark
 
-Los experimentos de comparación con algoritmos **no supervisados** se encuentran
-en la carpeta [`experiments/`](experiments/). El script
-[`compare_unsupervised.py`](experiments/compare_unsupervised.py) evalúa cinco
-conjuntos de datos distintos, explora parámetros de **SheShe**, **KMeans** y
-**DBSCAN**, y almacena cuatro métricas (`ARI`, `homogeneity`, `completeness`,
-`v_measure`) junto con el tiempo de ejecución (`runtime_sec`).
+The experiments comparing against **unsupervised** algorithms are located in
+the [`experiments/`](experiments/) folder. The script
+[`compare_unsupervised.py`](experiments/compare_unsupervised.py) evaluates five
+different datasets, explores parameters of **SheShe**, **KMeans** and
+**DBSCAN**, and stores four metrics (`ARI`, `homogeneity`, `completeness`,
+`v_measure`) along with the execution time (`runtime_sec`).
 
 ```bash
 python experiments/compare_unsupervised.py
 cat benchmark/unsupervised_results.csv | head
 ```
 
-se generan los resultados dentro de `benchmark/`.
+Results are generated inside `benchmark/`.
 
 ---
 
-## Parámetros clave
-- `base_2d_rays` → controla la resolución angular en 2D (8 por defecto). 3D escala ~26; d>3 usa subespacios.
-- `direction` → "center_out" | "outside_in" para localizar el punto de inflexión.
-- `scan_radius_factor`, `scan_steps` → tamaño y resolución del escaneo radial.
-- `grad_*` → hiperparámetros del ascenso (tasa, iteraciones, tolerancias).
-- `max_subspaces` → nº máx. de subespacios considerados cuando d>3.
+## Key parameters
+- `base_2d_rays` → controls angular resolution in 2D (8 by default). 3D scales
+  to ~26; d>3 uses subspaces.
+- `direction` → "center_out" | "outside_in" to locate the inflection point.
+- `scan_radius_factor`, `scan_steps` → size and resolution of the radial scan.
+- `grad_*` → hyperparameters of gradient ascent (rate, iterations, tolerances).
+- `max_subspaces` → max number of subspaces considered when d>3.
 
 ---
 
-## Limitaciones
-- Depende de la **superficie** producida por el modelo base (puede ser rugosa en RF).
-- En alta dimensión, la frontera es una **aproximación** (subespacios).
-- Encuentra **máximos locales** (no garantiza el global), mitigado con múltiples *seeds*.
+## Limitations
+- Depends on the **surface** produced by the base model (can be rough in RF).
+- In high dimension, the boundary is an **approximation** (subspaces).
+- Finds **local maxima** (does not guarantee the global one), mitigated with
+  multiple seeds.
 
 ---
 
-## Contribuir
+## Contribute
 
-Las mejoras son bienvenidas. Para proponer cambios:
+Improvements are welcome. To propose changes:
 
-1. Haz un *fork* del repositorio y crea una rama descriptiva.
-2. Instala las dependencias de desarrollo y ejecuta los tests:
+1. Fork the repository and create a descriptive branch.
+2. Install development dependencies and run the tests:
 
    ```bash
    pip install -e ".[dev]"
    PYTHONPATH=src pytest -q
    ```
-3. Envía un *pull request* con una descripción clara del cambio.
+3. Submit a pull request with a clear description of the change.
 
 ---
 
-## Licencia
+## License
 MIT
+

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,0 +1,233 @@
+# SheShe  
+**Smart High-dimensional Edge Segmentation & Hyperboundary Explorer**
+
+Segmentación de bordes y exploración de hiper-fronteras basada en **máximos locales** de
+la **probabilidad por clase** (clasificación) o del **valor predicho** (regresión).
+
+---
+
+## Instalación
+
+Requiere **Python >=3.9** y se recomienda el uso de un entorno virtual.
+
+```bash
+pip install -e .
+```
+
+Dependencias base: `numpy`, `pandas`, `scikit-learn>=1.1`, `matplotlib`
+
+Para un entorno de desarrollo con pruebas:
+
+```bash
+pip install -e ".[dev]"
+PYTHONPATH=src pytest -q
+```
+
+---
+
+## API rápida
+
+```python
+from sheshe import ModalBoundaryClustering
+
+# clasificación
+clf = ModalBoundaryClustering(
+    base_estimator=None,           # por defecto LogisticRegression
+    task="classification",         # "classification" | "regression"
+    base_2d_rays=8,                # nº de rayos en 2D (≈45°)
+    direction="center_out",        # "center_out" | "outside_in"
+    scan_radius_factor=3.0,
+    scan_steps=64,
+    random_state=0
+)
+
+# regresión (ejemplo)
+reg = ModalBoundaryClustering(task="regression")
+```
+
+### Métodos
+- `fit(X, y)`
+- `predict(X)`
+- `predict_proba(X)`  → clasificación: probas por clase; regresión: valor normalizado [0,1]
+- `interpretability_summary(feature_names=None)` → DataFrame con:
+  - `Tipo`: "centroide" | "inflexion_point"
+  - `Distancia`: radio desde el centro al punto de inflexión
+  - `Categoria`: clase (o "NA" en regresión)
+  - `pendiente`: df/dt en el punto de inflexión
+  - `valor_real` / `valor_norm`
+  - `coord_0..coord_{d-1}` o nombres de features
+- `plot_pairs(X, y=None, max_pairs=None)` → gráficos 2D para todas las combinaciones de pares
+- `save(filepath)` → guarda el modelo mediante `joblib`
+- `ModalBoundaryClustering.load(filepath)` → carga una instancia guardada
+
+---
+
+## ¿Cómo funciona?
+1. Entrena/usa un **modelo base** de sklearn (clasificación con `predict_proba` o regresión con `predict`).
+2. Busca **máximos locales** por **ascenso de gradiente** con barreras en los límites del dominio.
+3. Desde el máximo, traza **rayos** (direcciones) en la hiperesfera:
+   - 2D: 8 rayos por defecto
+   - 3D: ~26 direcciones (cobertura por *caps* esféricos con muestreo Fibonacci)
+   - >3D: mezcla de unas pocas direcciones globales + **subespacios** 2D/3D
+4. Sobre cada rayo, **escanea radialmente** y calcula el **primer punto de inflexión** según `direction`:
+   - `center_out`: desde el centro hacia fuera
+   - `outside_in`: desde el exterior hacia el centro
+   Registra además la **pendiente** (df/dt) en ese punto.
+5. Conecta los puntos de inflexión para formar la **frontera** de la región de alta probabilidad/valor.
+
+---
+
+## Ejemplos
+### Clasificación — Iris
+```python
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+from sheshe import ModalBoundaryClustering
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+sh = ModalBoundaryClustering(
+    base_estimator=LogisticRegression(max_iter=1000),
+    task="classification",
+    base_2d_rays=8,
+    random_state=0,
+).fit(X, y)
+
+print(sh.interpretability_summary(iris.feature_names).head())
+sh.plot_pairs(X, y, max_pairs=3)   # genera las gráficas
+plt.show()
+```
+
+### Clasificación con modelo ya entrenado
+```python
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_wine
+from sklearn.ensemble import RandomForestClassifier
+from sheshe import ModalBoundaryClustering
+
+wine = load_wine()
+X, y = wine.data, wine.target
+
+# Entrena un modelo de forma independiente
+base_model = RandomForestClassifier(n_estimators=200, random_state=0)
+base_model.fit(X, y)
+
+# Usa SheShe con ese modelo ya ajustado
+sh = ModalBoundaryClustering(
+    base_estimator=base_model,
+    task="classification",
+    base_2d_rays=8,
+    random_state=0,
+).fit(X, y)
+
+sh.plot_pairs(X, y, max_pairs=2)
+plt.show()
+```
+
+### Regresión — Diabetes
+```python
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_diabetes
+from sklearn.ensemble import GradientBoostingRegressor
+from sheshe import ModalBoundaryClustering
+
+diab = load_diabetes()
+X, y = diab.data, diab.target
+
+sh = ModalBoundaryClustering(
+    base_estimator=GradientBoostingRegressor(random_state=0),
+    task="regression",
+    base_2d_rays=8,
+    random_state=0,
+).fit(X, y)
+
+print(sh.interpretability_summary(diab.feature_names).head())
+sh.plot_pairs(X, max_pairs=3)
+plt.show()
+```
+
+### Guardado de gráficas
+```python
+from pathlib import Path
+import matplotlib.pyplot as plt
+
+# tras llamar a ``sh.plot_pairs(...)``
+out_dir = Path("imagenes")
+out_dir.mkdir(exist_ok=True)
+for i, fig_num in enumerate(plt.get_fignums()):
+    plt.figure(fig_num)
+    plt.savefig(out_dir / f"pair_{i}.png")
+    plt.close(fig_num)
+```
+
+### Guardar y cargar modelo
+```python
+from pathlib import Path
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+sh = ModalBoundaryClustering().fit(X, y)
+ruta = Path("sheshe_model.joblib")
+sh.save(ruta)
+sh2 = ModalBoundaryClustering.load(ruta)
+print((sh.predict(X) == sh2.predict(X)).all())
+```
+
+Para ejemplos más completos, consulta la carpeta `examples/`.
+
+### Experimentos y benchmark
+
+Los experimentos de comparación con algoritmos **no supervisados** se encuentran
+en la carpeta [`experiments/`](experiments/). El script
+[`compare_unsupervised.py`](experiments/compare_unsupervised.py) evalúa cinco
+conjuntos de datos distintos, explora parámetros de **SheShe**, **KMeans** y
+**DBSCAN**, y almacena cuatro métricas (`ARI`, `homogeneity`, `completeness`,
+`v_measure`) junto con el tiempo de ejecución (`runtime_sec`).
+
+```bash
+python experiments/compare_unsupervised.py
+cat benchmark/unsupervised_results.csv | head
+```
+
+se generan los resultados dentro de `benchmark/`.
+
+---
+
+## Parámetros clave
+- `base_2d_rays` → controla la resolución angular en 2D (8 por defecto). 3D escala ~26; d>3 usa subespacios.
+- `direction` → "center_out" | "outside_in" para localizar el punto de inflexión.
+- `scan_radius_factor`, `scan_steps` → tamaño y resolución del escaneo radial.
+- `grad_*` → hiperparámetros del ascenso (tasa, iteraciones, tolerancias).
+- `max_subspaces` → nº máx. de subespacios considerados cuando d>3.
+
+---
+
+## Limitaciones
+- Depende de la **superficie** producida por el modelo base (puede ser rugosa en RF).
+- En alta dimensión, la frontera es una **aproximación** (subespacios).
+- Encuentra **máximos locales** (no garantiza el global), mitigado con múltiples *seeds*.
+
+---
+
+## Contribuir
+
+Las mejoras son bienvenidas. Para proponer cambios:
+
+1. Haz un *fork* del repositorio y crea una rama descriptiva.
+2. Instala las dependencias de desarrollo y ejecuta los tests:
+
+   ```bash
+   pip install -e ".[dev]"
+   PYTHONPATH=src pytest -q
+   ```
+3. Envía un *pull request* con una descripción clara del cambio.
+
+---
+
+## Licencia
+MIT

--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -23,26 +23,26 @@ from sklearn.utils.validation import check_is_fitted
 
 
 # =========================
-# Utilidades numéricas
+# Numerical utilities
 # =========================
 
 def _rng(random_state: Optional[int]) -> np.random.RandomState:
     return np.random.RandomState(None if random_state is None else int(random_state))
 
 def sample_unit_directions_gaussian(n: int, dim: int, random_state: Optional[int] = 42) -> np.ndarray:
-    """Direcciones ~uniformes en S^{dim-1} normalizando gaussianas."""
+    """Approximately uniform directions on :math:`S^{dim-1}` by normalizing Gaussian samples."""
     rng = _rng(random_state)
     U = rng.normal(size=(n, dim))
     U /= (np.linalg.norm(U, axis=1, keepdims=True) + 1e-12)
     return U
 
 def sample_unit_directions_circle(n: int) -> np.ndarray:
-    """2D: n ángulos equiespaciados."""
+    """2D: ``n`` evenly spaced angles."""
     ang = np.linspace(0, 2*np.pi, n, endpoint=False)
     return np.column_stack([np.cos(ang), np.sin(ang)])
 
 def sample_unit_directions_sph_fibo(n: int) -> np.ndarray:
-    """3D: puntos casi equi-área en S^2 (Fibonacci esférico)."""
+    """3D: nearly equal-area points on :math:`S^2` (spherical Fibonacci)."""
     ga = (1 + 5 ** 0.5) / 2  # golden ratio
     k = np.arange(n)
     z = 1 - (2*k + 1)/n
@@ -53,7 +53,7 @@ def sample_unit_directions_sph_fibo(n: int) -> np.ndarray:
     return np.column_stack([x, y, z])
 
 def finite_diff_gradient(f, x: np.ndarray, eps: float = 1e-2) -> np.ndarray:
-    """Gradiente por diferencia central."""
+    """Central difference gradient."""
     d = x.shape[0]
     g = np.zeros(d, dtype=float)
     for i in range(d):
@@ -62,10 +62,8 @@ def finite_diff_gradient(f, x: np.ndarray, eps: float = 1e-2) -> np.ndarray:
     return g
 
 def project_step_with_barrier(x: np.ndarray, g: np.ndarray, lo: np.ndarray, hi: np.ndarray) -> np.ndarray:
-    """
-    Anula componentes del gradiente que empujan fuera del dominio cuando estamos en el borde.
-    Evita 'escaparse' y fuerza el movimiento por otras variables.
-    """
+    """Zero out gradient components that push outside the domain when on the boundary.
+    Prevents escaping and forces movement along other variables."""
     step = g.copy()
     for i in range(len(x)):
         if (x[i] <= lo[i] + 1e-12 and step[i] < 0) or (x[i] >= hi[i] - 1e-12 and step[i] > 0):
@@ -76,7 +74,7 @@ def gradient_ascent(
     f, x0: np.ndarray, bounds: Tuple[np.ndarray, np.ndarray],
     lr: float = 0.1, max_iter: int = 200, tol: float = 1e-5, eps_grad: float = 1e-2
 ) -> np.ndarray:
-    """Ascenso con backtracking y barreras en los límites."""
+    """Gradient ascent with backtracking and boundary barriers."""
     lo, hi = bounds
     x = x0.copy()
     best = f(x)
@@ -108,15 +106,24 @@ def second_diff(arr: np.ndarray) -> np.ndarray:
     return s
 
 def find_inflection(ts: np.ndarray, vals: np.ndarray, direction: str) -> Tuple[float, float]:
-    """
-    Devuelve (t_inf, slope_at_inf). direction: 'center_out' | 'outside_in'.
-    - t_inf: parámetro t en [0,T]
-    - slope_at_inf: df/dt en t_inf (signo coherente con t creciente).
+    """Return ``(t_inf, slope_at_inf)``.
+
+    Parameters
+    ----------
+    direction : {'center_out', 'outside_in'}
+        Scanning strategy.
+
+    Returns
+    -------
+    t_inf : float
+        Parameter ``t`` in ``[0, T]``.
+    slope_at_inf : float
+        ``df/dt`` at ``t_inf`` (sign consistent with increasing ``t``).
     """
     if direction not in ("center_out", "outside_in"):
-        raise ValueError("direction debe ser 'center_out' u 'outside_in'.")
+        raise ValueError("direction must be 'center_out' or 'outside_in'.")
 
-    # Prepara serie según dirección
+    # Prepare series according to direction
     if direction == "outside_in":
         ts_scan = ts[::-1]
         vals_scan = vals[::-1]
@@ -141,16 +148,16 @@ def find_inflection(ts: np.ndarray, vals: np.ndarray, direction: str) -> Tuple[f
         return (vals_scan[idx0+1] - vals_scan[idx0-1]) / (ts_scan[idx0+1] - ts_scan[idx0-1] + 1e-12)
 
     if idx is not None and 1 <= idx < len(ts_scan):
-        # interpola posición exacta entre idx-1 e idx
+        # interpolate exact position between idx-1 and idx
         j0, j1 = idx-1, idx
         a0, a1 = sd[j0], sd[j1]
         frac = float(np.clip(-a0 / (a1 - a0 + 1e-12), 0.0, 1.0))
         t_scan = ts_scan[j0] + frac * (ts_scan[j1] - ts_scan[j0])
-        # pendiente (usar índice más cercano)
+        # slope (use nearest index)
         j_star = j0 if frac < 0.5 else j1
         m_scan = slope_at(j_star)
     else:
-        # fallback: 50% de caída desde val[0]
+        # fallback: 50% drop from val[0]
         target = vals_scan[0] * 0.5
         t_scan = ts_scan[-1]
         m_scan = slope_at(len(ts_scan)//2)
@@ -169,52 +176,52 @@ def find_inflection(ts: np.ndarray, vals: np.ndarray, direction: str) -> Tuple[f
 
 
 # =========================
-# Estructuras de salida
+# Output structures
 # =========================
 
 @dataclass
 class ClusterRegion:
-    label: Union[int, str]                 # clase (o "NA" en regresión)
-    center: np.ndarray                     # máximo local
+    label: Union[int, str]                 # class (or "NA" in regression)
+    center: np.ndarray                     # local maximum
     directions: np.ndarray                 # (n_rays, d)
     radii: np.ndarray                      # (n_rays,)
     inflection_points: np.ndarray          # (n_rays, d)
-    inflection_slopes: np.ndarray          # (n_rays,) df/dt en inflexión
-    peak_value_real: float                 # prob/valor real en el centro
-    peak_value_norm: float                 # valor normalizado en el centro [0,1]
+    inflection_slopes: np.ndarray          # (n_rays,) df/dt at inflection
+    peak_value_real: float                 # real prob/value at the center
+    peak_value_norm: float                 # normalized value at the center [0,1]
 
 
 # =========================
-# Plan de muestreo de rays
+# Ray sampling plan
 # =========================
 
 def rays_count_auto(dim: int, base_2d: int = 8) -> int:
-    """
-    Nº de rays sugerido según dimensión:
-      - 2D: base_2d (por defecto 8)
-      - 3D: N ≈ 2 / (1 - cos(π/base_2d))  (cobertura por caps; ~26 si base_2d=8)
-      - >3D: mantener coste acotado: usamos subespacios → devolver pequeño nº global.
+    """Suggested number of rays depending on dimension.
+
+    - 2D: ``base_2d`` (default 8)
+    - 3D: ``N ≈ 2 / (1 - cos(π/base_2d))`` (cap coverage; ~26 if ``base_2d=8``)
+    - >3D: keep the cost bounded by using subspaces → return a small global count.
     """
     if dim <= 1:
         return 1
     if dim == 2:
         return int(base_2d)
     if dim == 3:
-        theta = math.pi / base_2d  # ≈ separación angular análoga a 2D
+        theta = math.pi / base_2d  # ≈ 2D-like angular separation
         n = max(12, int(math.ceil(2.0 / max(1e-9, (1 - math.cos(theta))))))
         return min(64, n)  # cota superior razonable
-    # Para >3D devolvemos unos pocos globales; el resto irá por subespacios
+    # For >3D return a few global ones; the rest via subspaces
     return 8
 
 def generate_directions(dim: int, base_2d: int, random_state: Optional[int] = 42,
                         max_subspaces: int = 20) -> np.ndarray:
-    """
-    Conjunto de direcciones:
-      - 2D: 8 equiángulos (por defecto)
-      - 3D: ~N por fórmula de caps + Fibonacci esférico
-      - >3D: mezcla de:
-          * pequeños globales (gaussianos) y
-          * direcciones embebidas en subespacios 2D/3D (todas o muestreadas)
+    """Set of directions.
+
+    - 2D: 8 equally spaced angles (default)
+    - 3D: ``~N`` from the cap formula + spherical Fibonacci
+    - >3D: mixture of:
+        * a few global (Gaussian) directions, and
+        * directions embedded in 2D/3D subspaces (all or sampled)
     """
     if dim == 1:
         return np.array([[1.0]])
@@ -231,7 +238,7 @@ def generate_directions(dim: int, base_2d: int, random_state: Optional[int] = 42
     # algunos globales
     dirs.append(sample_unit_directions_gaussian(rays_count_auto(dim, base_2d), dim, random_state))
 
-    # elige subespacios de tamaño 3 (o 2 si dim=4 y quieres más baratas)
+    # choose subspaces of size 3 (or 2 if dim=4 and you want cheaper)
     sub_dim = 3 if dim >= 3 else 2
     total_combos = math.comb(dim, sub_dim)
     if max_subspaces >= total_combos:
@@ -268,17 +275,18 @@ def generate_directions(dim: int, base_2d: int, random_state: Optional[int] = 42
 # =========================
 
 class ModalBoundaryClustering(BaseEstimator):
-    """
-    SheShe: Smart High-dimensional Edge Segmentation & Hyperboundary Explorer
+    """SheShe: Smart High-dimensional Edge Segmentation & Hyperboundary Explorer
 
-    Clusterización por máximos locales sobre la superficie de probabilidad (clasificación)
-    o del valor predicho (regresión). Compatible con sklearn.
+    Clusters around local maxima on the probability surface (classification) or
+    the predicted value (regression). Compatible with sklearn.
 
-    Novedades v2:
-      - Nº de rays dinámico: 2D→8; 3D≈26; >3D se reduce con subespacios (2D/3D) + pocos globales.
-      - `direction`: 'center_out' (default) o 'outside_in' para localizar la inflexión.
-      - Pendiente en punto de inflexión (df/dt).
-      - Ascenso con barreras en bordes.
+    Version 2 highlights:
+      - Dynamic number of rays: 2D→8; 3D≈26; >3D reduced with 2D/3D subspaces
+        plus a few global ones.
+      - ``direction``: 'center_out' (default) or 'outside_in' to locate the
+        inflection.
+      - Slope at the inflection point (df/dt).
+      - Ascent with boundary barriers.
     """
 
     def __init__(
@@ -287,7 +295,7 @@ class ModalBoundaryClustering(BaseEstimator):
         task: str = "classification",  # "classification" | "regression"
         base_2d_rays: int = 8,
         direction: str = "center_out",
-        scan_radius_factor: float = 3.0,   # múltiplos del std global
+        scan_radius_factor: float = 3.0,   # multiples of the global std
         scan_steps: int = 64,
         grad_lr: float = 0.2,
         grad_max_iter: int = 200,
@@ -342,7 +350,7 @@ class ModalBoundaryClustering(BaseEstimator):
         Xs = self.scaler_.transform(X)
         if self.task == "classification":
             if class_idx is None:
-                raise ValueError("class_idx requerido en clasificación.")
+                raise ValueError("class_idx required for classification.")
             proba = self.estimator_.predict_proba(Xs)
             return proba[:, class_idx]
         else:
@@ -384,9 +392,8 @@ class ModalBoundaryClustering(BaseEstimator):
 
     def _scan_radii(self, center: np.ndarray, f, directions: np.ndarray, X_std: np.ndarray
                    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """
-        Para cada dirección u: escaneo radial t∈[0,T] y primer punto de inflexión según `direction`.
-        Devuelve (radii, points, slopes).
+        """For each direction ``u``: radial scan ``t∈[0,T]`` and first inflection point
+        according to ``direction``. Returns ``(radii, points, slopes)``.
         """
         d = center.shape[0]
         T = float(self.scan_radius_factor * np.linalg.norm(X_std))
@@ -426,10 +433,10 @@ class ModalBoundaryClustering(BaseEstimator):
                 label_path = label_path.with_suffix(".labels")
         try:
             np.savetxt(label_path, labels, fmt="%s")
-        except Exception as exc:  # pragma: no cover - logging auxiliar
-            self._log(f"No se pudieron guardar etiquetas en {label_path}: {exc}")
+        except Exception as exc:  # pragma: no cover - auxiliary logging
+            self._log(f"Could not save labels to {label_path}: {exc}")
 
-    # ---------- API pública ----------
+    # ---------- Public API ----------
 
     def fit(self, X: Union[np.ndarray, pd.DataFrame], y: Optional[np.ndarray] = None):
         start = time.perf_counter()
@@ -474,34 +481,34 @@ class ModalBoundaryClustering(BaseEstimator):
                     peak_value_real=peak_real, peak_value_norm=peak_norm
                 ))
         except Exception as exc:
-            self._log(f"Error en fit: {exc}")
+            self._log(f"Error in fit: {exc}")
             raise
         runtime = time.perf_counter() - start
-        self._log(f"fit completado en {runtime:.4f}s")
+        self._log(f"fit completed in {runtime:.4f}s")
         return self
 
     def fit_predict(self, X: Union[np.ndarray, pd.DataFrame], y: Optional[np.ndarray] = None) -> np.ndarray:
-        """Ajusta el modelo y devuelve la predicción para ``X``.
+        """Fit the model and return the prediction for ``X``.
 
-        Atajo común en *sklearn* que equivale a llamar a :meth:`fit` y
-        posteriormente a :meth:`predict` sobre los mismos datos.
+        Common *sklearn* shortcut equivalent to calling :meth:`fit` and then
+        :meth:`predict` on the same data.
         """
         self.fit(X, y)
         return self.predict(X)
 
     def _membership_matrix(self, X: np.ndarray) -> np.ndarray:
-        """Construye la matriz de pertenencia a las regiones descubiertas.
+        """Build the membership matrix for the discovered regions.
 
         Parameters
         ----------
         X : ndarray of shape (n_samples, n_features)
-            Muestras a evaluar en el espacio original.
+            Samples to evaluate in the original space.
 
         Returns
         -------
         ndarray of shape (n_samples, n_regions)
-            Matriz binaria ``R`` donde ``R[i, k] = 1`` indica que la muestra
-            ``i`` cae dentro de la región ``k``.
+            Binary matrix ``R`` where ``R[i, k] = 1`` indicates sample ``i`` falls
+            inside region ``k``.
 
         Examples
         --------
@@ -534,11 +541,11 @@ class ModalBoundaryClustering(BaseEstimator):
         X: Union[np.ndarray, pd.DataFrame],
         label_path: Optional[Union[str, Path]] = None,
     ) -> np.ndarray:
-        """Predicción para ``X``.
+        """Prediction for ``X``.
 
-        Clasificación → etiqueta de la región correspondiente (con *fallback*
-        al estimador base si el punto no pertenece a ninguna). Regresión →
-        valor predicho por el estimador base.
+        Classification → label of the corresponding region (with a fallback to
+        the base estimator if the point is outside all regions). Regression →
+        predicted value from the base estimator.
         """
         start = time.perf_counter()
         try:
@@ -564,15 +571,18 @@ class ModalBoundaryClustering(BaseEstimator):
             else:
                 result = self.pipeline_.predict(X)
         except Exception as exc:
-            self._log(f"Error en predict: {exc}")
+            self._log(f"Error in predict: {exc}")
             raise
         runtime = time.perf_counter() - start
-        self._log(f"predict completado en {runtime:.4f}s")
+        self._log(f"predict completed in {runtime:.4f}s")
         self._maybe_save_labels(result, label_path)
         return result
 
     def predict_proba(self, X: Union[np.ndarray, pd.DataFrame]) -> np.ndarray:
-        """Clasificación: proba por clase del estimador base. Regresión: valor normalizado [0,1]."""
+        """Classification: class probabilities from the base estimator.
+
+        Regression: normalized value in ``[0, 1]``.
+        """
         start = time.perf_counter()
         try:
             check_is_fitted(self, "regions_")
@@ -586,33 +596,32 @@ class ModalBoundaryClustering(BaseEstimator):
                 rng = vmax - vmin if vmax > vmin else 1.0
                 result = ((vals - vmin) / rng).reshape(-1, 1)
         except Exception as exc:
-            self._log(f"Error en predict_proba: {exc}")
+            self._log(f"Error in predict_proba: {exc}")
             raise
         runtime = time.perf_counter() - start
-        self._log(f"predict_proba completado en {runtime:.4f}s")
+        self._log(f"predict_proba completed in {runtime:.4f}s")
         return result
 
     def decision_function(self, X: Union[np.ndarray, pd.DataFrame]) -> np.ndarray:
-        """Valores de decisión del estimador base con *fallback* automático.
+        """Decision values from the base estimator with automatic fallback.
 
-        Si el estimador subyacente dispone de :meth:`decision_function`, se
-        devuelve dicha salida. En caso contrario se recurre a
-        :meth:`predict_proba` para tareas de clasificación o a
-        :meth:`predict` para regresión.
+        If the underlying estimator provides :meth:`decision_function`, that
+        output is returned. Otherwise we fall back to :meth:`predict_proba` for
+        classification or :meth:`predict` for regression.
 
         Parameters
         ----------
-        X:
-            Muestras a evaluar.
+        X : array-like
+            Samples to evaluate.
 
         Returns
         -------
         ndarray
-            Puntajes, probabilidades o predicciones dependiendo del *fallback*.
+            Scores, probabilities or predictions depending on the fallback.
 
         Examples
         --------
-        Clasificación con un estimador que implementa ``decision_function``::
+        Classification with an estimator implementing ``decision_function``::
 
             >>> from sklearn.datasets import load_iris
             >>> from sklearn.linear_model import LogisticRegression
@@ -622,7 +631,7 @@ class ModalBoundaryClustering(BaseEstimator):
             >>> sh.decision_function(X[:2]).shape
             (2, 3)
 
-        Clasificación con un modelo sin ``decision_function`` (usa
+        Classification with a model lacking ``decision_function`` (uses
         ``predict_proba``)::
 
             >>> from sklearn.ensemble import RandomForestClassifier
@@ -631,7 +640,7 @@ class ModalBoundaryClustering(BaseEstimator):
             >>> sh.decision_function(X[:2]).shape
             (2, 3)
 
-        En regresión la salida proviene de ``predict``::
+        For regression the output comes from ``predict``::
 
             >>> from sklearn.datasets import make_regression
             >>> from sklearn.ensemble import RandomForestRegressor
@@ -654,43 +663,41 @@ class ModalBoundaryClustering(BaseEstimator):
                 else:
                     result = self.estimator_.predict(Xs)
         except Exception as exc:
-            self._log(f"Error en decision_function: {exc}")
+            self._log(f"Error in decision_function: {exc}")
             raise
         runtime = time.perf_counter() - start
-        self._log(f"decision_function completado en {runtime:.4f}s")
+        self._log(f"decision_function completed in {runtime:.4f}s")
         return result
 
     def score(self, X: Union[np.ndarray, pd.DataFrame], y: np.ndarray) -> float:
-        """Devuelve la métrica de sklearn delegando en el pipeline interno."""
+        """Return the sklearn metric delegating to the internal pipeline."""
         check_is_fitted(self, "pipeline_")
         return self.pipeline_.score(np.asarray(X, dtype=float), y)
 
     def save(self, filepath: Union[str, Path]) -> None:
-        """Guarda la instancia actual en ``filepath`` usando ``joblib.dump``."""
+        """Save the current instance to ``filepath`` using ``joblib.dump``."""
         joblib.dump(self, filepath)
 
     @classmethod
     def load(cls, filepath: Union[str, Path]) -> "ModalBoundaryClustering":
-        """Carga una instancia previamente guardada con :meth:`save`."""
+        """Load a previously saved instance with :meth:`save`."""
         return joblib.load(filepath)
 
     def interpretability_summary(self, feature_names: Optional[List[str]] = None) -> pd.DataFrame:
-        """Resume centros e inflexiones de cada región en un ``DataFrame``.
+        """Summarize centers and inflection points of each region in a ``DataFrame``.
 
         Parameters
         ----------
         feature_names : list of str, optional
-            Nombres de las características de longitud ``(n_features,)``.
-            Cuando es ``None`` se utilizan los nombres vistos durante el
-            ajuste o ``coord_i`` si no están disponibles.
+            Feature names of length ``(n_features,)``. When ``None``, use the
+            names seen during fitting or ``coord_i`` if unavailable.
 
         Returns
         -------
         DataFrame
-            Tabla con una fila por centroide y punto de inflexión. Contiene
-            las columnas ``['Tipo', 'Distancia', 'Categoria', 'valor_real',
-            'valor_norm', 'pendiente']`` además de una columna por
-            característica.
+            Table with one row per centroid and inflection point. Contains the
+            columns ``['Type', 'Distance', 'Category', 'real_value',
+            'norm_value', 'slope']`` plus one column per feature.
 
         Examples
         --------
@@ -698,7 +705,7 @@ class ModalBoundaryClustering(BaseEstimator):
         >>> X, y = load_iris(return_X_y=True)
         >>> sh = ModalBoundaryClustering().fit(X, y)
         >>> sh.interpretability_summary().head()
-           
+
         """
         check_is_fitted(self, "regions_")
         d = self.n_features_in_
@@ -719,7 +726,7 @@ class ModalBoundaryClustering(BaseEstimator):
             for j in range(d):
                 row_c[feature_names[j]] = float(reg.center[j])
             rows.append(row_c)
-            # puntos de inflexión
+            # inflection points
             if self.task == "classification":
                 cls_index = list(self.estimator_.classes_).index(reg.label)
             else:
@@ -738,26 +745,26 @@ class ModalBoundaryClustering(BaseEstimator):
                 rows.append(row_i)
         return pd.DataFrame(rows)
 
-    # -------- Visualización (pares 2D) --------
+    # -------- Visualization (2D pairs) --------
 
     def _plot_single_pair_classif(self, X: np.ndarray, y: np.ndarray, pair: Tuple[int, int],
                                   class_colors: Dict[Any, str], grid_res: int = 200, alpha_surface: float = 0.6):
-        """Dibuja la superficie de probabilidad para un par de características.
+        """Draw the probability surface for a pair of features.
 
         Parameters
         ----------
         X : ndarray of shape (n_samples, n_features)
-            Matriz de características.
+            Feature matrix.
         y : ndarray of shape (n_samples,)
-            Etiquetas de clase.
+            Class labels.
         pair : tuple of int
-            Índices ``(i, j)`` de las características a graficar.
+            Indices ``(i, j)`` of the features to plot.
         class_colors : dict
-            Mapeo de clase a color para los puntos del diagrama.
+            Mapping from class to color for scatter points.
         grid_res : int, default=200
-            Resolución de la malla usada para la superficie.
+            Resolution of the mesh used for the surface.
         alpha_surface : float, default=0.6
-            Transparencia de la superficie.
+            Surface transparency.
 
         Returns
         -------
@@ -810,18 +817,18 @@ class ModalBoundaryClustering(BaseEstimator):
 
     def _plot_single_pair_reg(self, X: np.ndarray, pair: Tuple[int, int],
                               grid_res: int = 200, alpha_surface: float = 0.6):
-        """Dibuja la superficie del valor predicho para un par de características.
+        """Draw the predicted-value surface for a pair of features.
 
         Parameters
         ----------
         X : ndarray of shape (n_samples, n_features)
-            Matriz de características.
+            Feature matrix.
         pair : tuple of int
-            Índices ``(i, j)`` de las características a graficar.
+            Indices ``(i, j)`` of the features to plot.
         grid_res : int, default=200
-            Resolución de la malla usada para la superficie.
+            Resolution of the mesh used for the surface.
         alpha_surface : float, default=0.6
-            Transparencia de la superficie.
+            Surface transparency.
 
         Returns
         -------
@@ -866,21 +873,21 @@ class ModalBoundaryClustering(BaseEstimator):
 
     def plot_pairs(self, X: Union[np.ndarray, pd.DataFrame], y: Optional[np.ndarray] = None,
                    max_pairs: Optional[int] = None):
-        """Visualiza superficies 2D para pares de características.
+        """Visualize 2D surfaces for feature pairs.
 
-        Genera una figura por cada combinación ``(i, j)`` de características
-        hasta ``max_pairs``. En clasificación se muestra la probabilidad de
-        cada clase y en regresión el valor predicho.
+        Generates one figure for each ``(i, j)`` feature combination up to
+        ``max_pairs``. In classification, the probability of each class is shown;
+        in regression, the predicted value.
 
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
-            Datos usados para fijar el rango de cada eje.
+            Data used to set the range of each axis.
         y : ndarray of shape (n_samples,), optional
-            Etiquetas reales; requerido cuando ``task='classification'``.
+            True labels; required when ``task='classification'``.
         max_pairs : int, optional
-            Máximo número de combinaciones a graficar. Si es ``None`` se
-            generan todas las combinaciones posibles.
+            Maximum number of combinations to plot. If ``None`` all possible
+            combinations are generated.
 
         Returns
         -------
@@ -888,14 +895,14 @@ class ModalBoundaryClustering(BaseEstimator):
 
         Examples
         --------
-        Clasificación::
+        Classification::
 
             >>> from sklearn.datasets import load_iris
             >>> X, y = load_iris(return_X_y=True)
             >>> sh = ModalBoundaryClustering().fit(X, y)
             >>> sh.plot_pairs(X, y, max_pairs=1)
 
-        Regresión::
+        Regression::
 
             >>> from sklearn.datasets import make_regression
             >>> X, y = make_regression(n_samples=50, n_features=3, random_state=0)
@@ -910,7 +917,7 @@ class ModalBoundaryClustering(BaseEstimator):
             pairs = pairs[:max_pairs]
 
         if self.task == "classification":
-            assert y is not None, "y requerido para graficar clasificación."
+            assert y is not None, "y required to plot classification."
             assert len(y) == len(X), "X e y deben tener la misma longitud."
             palette = ["#e41a1c", "#377eb8", "#4daf4a", "#984ea3",
                        "#ff7f00", "#a65628", "#f781bf", "#999999"]


### PR DESCRIPTION
## Summary
- Translate main README to English and keep Spanish version as README_ES
- Convert ModalBoundaryClustering docstrings and helpers to English

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b92bed824832cbd56bdabf850ceef