### PR TITLE
Validate classification targets in fit

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -446,6 +446,13 @@ class ModalBoundaryClustering(BaseEstimator):
             self.n_features_in_ = X.shape[1]
             self.feature_names_in_ = list(X.columns) if isinstance(X, pd.DataFrame) else None
 
+            if self.task == "classification":
+                if y is None:
+                    raise ValueError("y cannot be None when task='classification'")
+                y_arr = np.asarray(y)
+                if np.unique(y_arr).size < 2:
+                    raise ValueError("y must contain at least two classes for classification")
+
             self._fit_estimator(X, y)
             lo, hi = self._bounds_from_data(X)
             X_std = np.std(X, axis=0) + 1e-12

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -114,3 +114,18 @@ def test_membership_matrix_no_directions():
 def test_n_max_seeds_minimum():
     with pytest.raises(ValueError, match="n_max_seeds"):
         ModalBoundaryClustering(n_max_seeds=0)
+
+
+def test_fit_raises_when_y_none_classification():
+    X = np.random.randn(10, 3)
+    sh = ModalBoundaryClustering(task="classification")
+    with pytest.raises(ValueError, match="y cannot be None"):
+        sh.fit(X, None)
+
+
+def test_fit_raises_with_single_class():
+    X = np.random.randn(10, 3)
+    y = np.zeros(10)
+    sh = ModalBoundaryClustering(task="classification")
+    with pytest.raises(ValueError, match="at least two classes"):
+        sh.fit(X, y)


### PR DESCRIPTION
## Summary
- ensure classification tasks validate `y` before fitting
- add tests for missing or single-class targets

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9e2804b8832ca75eafb6f29ca0bf