### PR TITLE
Validate empty input for fit and handle missing seeds

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -379,7 +379,7 @@ class ModalBoundaryClustering(BaseEstimator):
     def _find_maximum(self, X: np.ndarray, f, bounds: Tuple[np.ndarray, np.ndarray]) -> np.ndarray:
         seeds = self._choose_seeds(X, f, min(self.n_max_seeds, len(X)))
         if len(seeds) == 0:
-            return X[0]
+            raise ValueError("No seeds available to locate a maximum")
         best_x, best_v = seeds[0].copy(), f(seeds[0])
         for s in seeds:
             x_star = gradient_ascent(
@@ -443,6 +443,8 @@ class ModalBoundaryClustering(BaseEstimator):
         start = time.perf_counter()
         try:
             X = np.asarray(X, dtype=float)
+            if X.ndim != 2 or X.shape[0] == 0:
+                raise ValueError("X must be a 2D array with at least one sample")
             self.n_features_in_ = X.shape[1]
             self.feature_names_in_ = list(X.columns) if isinstance(X, pd.DataFrame) else None
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -114,3 +114,11 @@ def test_membership_matrix_no_directions():
 def test_n_max_seeds_minimum():
     with pytest.raises(ValueError, match="n_max_seeds"):
         ModalBoundaryClustering(n_max_seeds=0)
+
+
+def test_fit_raises_error_on_empty_X():
+    sh = ModalBoundaryClustering()
+    X = np.empty((0, 2))
+    y = np.empty((0,))
+    with pytest.raises(ValueError, match="at least one sample"):
+        sh.fit(X, y)


### PR DESCRIPTION
## Summary
- Ensure `fit` checks for at least one sample before processing
- Raise clear error in `_find_maximum` when no seeds are available
- Add regression test to confirm `fit` rejects empty input

## Testing
- `pytest -q` *(fails: command not found: pytest)*
- `pip install --break-system-packages -r requirements-dev.txt` *(fails: Cannot connect to proxy. No matching distribution found for pytest)*
- `python3 -m pytest tests/test_basic.py::test_fit_raises_error_on_empty_X -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_689b9e26d02c832ca1f84ad7a9a2bb06