### PR TITLE
Validate base_2d rays for 3D and add regression test

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -208,6 +208,8 @@ def rays_count_auto(dim: int, base_2d: int = 8) -> int:
     if dim == 2:
         return int(base_2d)
     if dim == 3:
+        if base_2d <= 0:
+            raise ValueError("base_2d must be positive for dim == 3")
         theta = math.pi / base_2d  # ≈ 2D-like angular separation
         n = max(12, int(math.ceil(2.0 / max(1e-9, (1 - math.cos(theta))))))
         return min(64, n)  # cota superior razonable

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -111,6 +111,19 @@ def test_membership_matrix_no_directions():
     assert np.all(pred == base_pred)
 
 
+def test_base_2d_rays_zero_raises_in_3d():
+    iris = load_iris()
+    X, y = iris.data[:, :3], iris.target
+    sh = ModalBoundaryClustering(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        base_2d_rays=0,
+        random_state=0,
+    )
+    with pytest.raises(ValueError, match="base_2d"):
+        sh.fit(X, y)
+
+
 def test_n_max_seeds_minimum():
     with pytest.raises(ValueError, match="n_max_seeds"):
         ModalBoundaryClustering(n_max_seeds=0)


### PR DESCRIPTION
## Summary
- ensure rays_count_auto checks base_2d is positive in 3D and raises ValueError otherwise
- add regression test asserting base_2d_rays=0 in 3D fails

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9e2acfc0832c9f5a94699254bfa4