### PR TITLE
Improve experiment scripts robustness and expand README plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,34 @@ out_dir.mkdir(exist_ok=True)
 for i, fig_num in enumerate(plt.get_fignums()):
     plt.figure(fig_num)
     plt.savefig(out_dir / f"pair_{i}.png")
-    plt.close(fig_num)
+plt.close(fig_num)
+```
+
+### Plotting with pandas DataFrames
+```python
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+iris = load_iris()
+df = pd.DataFrame(iris.data, columns=iris.feature_names)
+
+sh = ModalBoundaryClustering().fit(df, iris.target)
+sh.plot_pairs(df, iris.target, max_pairs=2)  # usa nombres de columnas en los ejes
+plt.show()
+```
+
+### Visualizing interpretability summary
+```python
+import matplotlib.pyplot as plt
+
+summary = sh.interpretability_summary(df.columns)
+centroids = summary[summary["Type"] == "centroid"]
+plt.scatter(centroids["coord_0"], centroids["coord_1"], c=centroids["Category"])
+plt.xlabel("coord_0")
+plt.ylabel("coord_1")
+plt.show()
 ```
 
 ### Save and load model
@@ -196,21 +223,22 @@ different datasets, explores parameters of **SheShe**, **KMeans** and
 `v_measure`) along with the execution time (`runtime_sec`).
 
 ```bash
-python experiments/compare_unsupervised.py
-cat benchmark/unsupervised_results.csv | head
+python experiments/compare_unsupervised.py --runs 5
+cat benchmark/unsupervised_results_summary.csv | head
 ```
 
-Results are generated inside `benchmark/`.
+Results are generated inside `benchmark/` (valores por repetición y medias en
+`*_summary.csv`).
 
 For the manuscript we provide additional scripts in
 [`paper_experiments.py`](experiments/paper_experiments.py) which perform
 supervised comparisons, ablation studies over `base_2d_rays` and `direction`,
 and sensitivity analyses w.r.t. dimensionality and Gaussian noise.  Executing
-the script generates reproducible tables (`*.csv`) and figures (`*.png`) under
-`benchmark/`:
+the script generates tables with todas las repeticiones y un resumen (`*_summary.csv`),
+además de figuras (`*.png`) bajo `benchmark/`:
 
 ```bash
-python experiments/paper_experiments.py
+python experiments/paper_experiments.py --runs 5
 ```
 
 ---

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -10,10 +10,12 @@ utilizadas en el artículo de SheShe.
 - **Métricas:** ARI, homogeneity, completeness, v_measure y tiempo de ejecución.
 - **Ejecución:**
   ```bash
-  python experiments/compare_unsupervised.py
+  python experiments/compare_unsupervised.py --runs 5
   ```
-  Los resultados se almacenan en `benchmark/unsupervised_results.csv` junto con
-  las etiquetas predichas (`*.labels`).
+  El parámetro `--runs` controla la cantidad de repeticiones con distintas
+  semillas. Los resultados individuales (`unsupervised_results.csv`) y el
+  resumen estadístico (`unsupervised_results_summary.csv`) se almacenan en
+  `benchmark/` junto con las etiquetas predichas (`*.labels`).
 
 ## Experimentos para el paper
 - **Script:** `paper_experiments.py`
@@ -25,6 +27,9 @@ utilizadas en el artículo de SheShe.
   gaussiano.
 - **Ejecución:**
   ```bash
-  python experiments/paper_experiments.py
+  python experiments/paper_experiments.py --runs 5
   ```
-  Genera tablas (`*.csv`) y figuras (`*.png`) dentro de `benchmark/`.
+  El argumento `--runs` fija el número de semillas empleadas. Se guardan las
+  ejecuciones individuales y un resumen con medias y desviaciones estándar para
+  cada experimento (`*_summary.csv`). Además, se generan las figuras (`*.png`)
+  dentro de `benchmark/`.

--- a/experiments/compare_unsupervised.py
+++ b/experiments/compare_unsupervised.py
@@ -10,8 +10,9 @@ Los resultados se guardan en ``benchmark/unsupervised_results.csv``.
 from pathlib import Path
 import math
 import time
-from typing import Iterable, Tuple, Optional
+from typing import Iterable, Tuple, Optional, Sequence
 
+import argparse
 import numpy as np
 import pandas as pd
 from sklearn.datasets import (
@@ -66,6 +67,7 @@ def run(
     verbose: bool = False,
     save_labels: bool = True,
     out_dir: Optional[Path] = None,
+    seeds: Sequence[int] | None = None,
 ) -> None:
     """Ejecuta el experimento de comparación y guarda resultados.
 
@@ -78,15 +80,21 @@ def run(
     out_dir:
         Directorio de salida donde se guardan los resultados y etiquetas. Por
         defecto se usa ``benchmark/`` en la raíz del proyecto.
+    seeds:
+        Secuencia de semillas para repetir cada experimento. Cuando es ``None``
+        se utilizan ``range(5)``.
     """
 
-    datasets = {
-        "iris": load_iris(return_X_y=True),
-        "wine": load_wine(return_X_y=True),
-        "breast_cancer": load_breast_cancer(return_X_y=True),
-        "moons": make_moons(n_samples=300, noise=0.05, random_state=0),
-        "blobs": make_blobs(n_samples=300, centers=3, random_state=0),
-    }
+    seeds = list(seeds or range(5))
+
+    def _datasets(seed: int):
+        return {
+            "iris": load_iris(return_X_y=True),
+            "wine": load_wine(return_X_y=True),
+            "breast_cancer": load_breast_cancer(return_X_y=True),
+            "moons": make_moons(n_samples=300, noise=0.05, random_state=seed),
+            "blobs": make_blobs(n_samples=300, centers=3, random_state=seed),
+        }
 
     metrics: Iterable[Metric] = [
         ("ARI", adjusted_rand_score),
@@ -109,104 +117,129 @@ def run(
             if verbose:
                 print(f"No se pudieron guardar etiquetas en {label_path}: {exc}")
 
-    for name, (X, y) in datasets.items():
-        n_classes = len(set(y))
+    for seed in seeds:
+        datasets = _datasets(seed)
+        for name, (X, y) in datasets.items():
+            n_classes = len(set(y))
 
-        # SheShe: barrido sobre C
-        for C in [0.1, 1.0, 10.0]:
-            start = time.perf_counter()
-            try:
-                sh = ModalBoundaryClustering(
-                    base_estimator=LogisticRegression(max_iter=500, C=C),
-                    task="classification",
-                    random_state=0,
-                ).fit(X, y)
-                y_pred = sh.predict(X)
-                metrics_dict = _evaluate(y, y_pred, metrics)
-                _save_labels(y_pred, f"{name}_SheShe_C-{C}.labels")
-            except Exception as exc:
-                y_pred = []
-                metrics_dict = {name: math.nan for name, _ in metrics}
+            # SheShe: barrido sobre C
+            for C in [0.1, 1.0, 10.0]:
+                start = time.perf_counter()
+                try:
+                    sh = ModalBoundaryClustering(
+                        base_estimator=LogisticRegression(max_iter=500, C=C, random_state=seed),
+                        task="classification",
+                        random_state=seed,
+                    ).fit(X, y)
+                    y_pred = sh.predict(X)
+                    metrics_dict = _evaluate(y, y_pred, metrics)
+                    _save_labels(y_pred, f"{name}_SheShe_C-{C}_seed-{seed}.labels")
+                except Exception as exc:
+                    y_pred = []
+                    metrics_dict = {name: math.nan for name, _ in metrics}
+                    if verbose:
+                        print(f"SheShe falló en {name} (C={C}, seed={seed}): {exc}")
+                runtime = time.perf_counter() - start
+                record = {
+                    "dataset": name,
+                    "algorithm": "SheShe",
+                    "params": f"C={C}",
+                    "seed": seed,
+                    "runtime_sec": runtime,
+                }
+                record.update(metrics_dict)
+                results.append(record)
                 if verbose:
-                    print(f"SheShe falló en {name} (C={C}): {exc}")
-            runtime = time.perf_counter() - start
-            record = {
-                "dataset": name,
-                "algorithm": "SheShe",
-                "params": f"C={C}",
-                "runtime_sec": runtime,
-            }
-            record.update(metrics_dict)
-            results.append(record)
-            if verbose:
-                print(
-                    f"SheShe {name} C={C} → {runtime:.4f}s"
-                )
+                    print(
+                        f"SheShe {name} C={C} seed={seed} → {runtime:.4f}s",
+                    )
 
-        # KMeans: variar n_clusters
-        for k in [n_classes - 1, n_classes, n_classes + 1]:
-            k = max(k, 1)
-            start = time.perf_counter()
-            try:
-                km = KMeans(n_clusters=k, random_state=0)
-                km.fit(X)
-                y_pred = km.labels_
-                metrics_dict = _evaluate(y, y_pred, metrics)
-                _save_labels(y_pred, f"{name}_KMeans_k-{k}.labels")
-            except Exception as exc:
-                y_pred = []
-                metrics_dict = {name: math.nan for name, _ in metrics}
+            # KMeans: variar n_clusters
+            for k in [n_classes - 1, n_classes, n_classes + 1]:
+                k = max(k, 1)
+                start = time.perf_counter()
+                try:
+                    km = KMeans(n_clusters=k, random_state=seed)
+                    km.fit(X)
+                    y_pred = km.labels_
+                    metrics_dict = _evaluate(y, y_pred, metrics)
+                    _save_labels(y_pred, f"{name}_KMeans_k-{k}_seed-{seed}.labels")
+                except Exception as exc:
+                    y_pred = []
+                    metrics_dict = {name: math.nan for name, _ in metrics}
+                    if verbose:
+                        print(f"KMeans falló en {name} (k={k}, seed={seed}): {exc}")
+                runtime = time.perf_counter() - start
+                record = {
+                    "dataset": name,
+                    "algorithm": "KMeans",
+                    "params": f"n_clusters={k}",
+                    "seed": seed,
+                    "runtime_sec": runtime,
+                }
+                record.update(metrics_dict)
+                results.append(record)
                 if verbose:
-                    print(f"KMeans falló en {name} (k={k}): {exc}")
-            runtime = time.perf_counter() - start
-            record = {
-                "dataset": name,
-                "algorithm": "KMeans",
-                "params": f"n_clusters={k}",
-                "runtime_sec": runtime,
-            }
-            record.update(metrics_dict)
-            results.append(record)
-            if verbose:
-                print(
-                    f"KMeans {name} k={k} → {runtime:.4f}s"
-                )
+                    print(
+                        f"KMeans {name} k={k} seed={seed} → {runtime:.4f}s",
+                    )
 
-        # DBSCAN: variar eps
-        for eps in [0.3, 0.5, 0.7]:
-            start = time.perf_counter()
-            try:
-                db = DBSCAN(eps=eps, min_samples=5)
-                db.fit(X)
-                y_pred = db.labels_
-                metrics_dict = _evaluate(y, y_pred, metrics)
-                _save_labels(y_pred, f"{name}_DBSCAN_eps-{eps}.labels")
-            except Exception as exc:
-                y_pred = []
-                metrics_dict = {name: math.nan for name, _ in metrics}
+            # DBSCAN: variar eps
+            for eps in [0.3, 0.5, 0.7]:
+                start = time.perf_counter()
+                try:
+                    db = DBSCAN(eps=eps, min_samples=5)
+                    db.fit(X)
+                    y_pred = db.labels_
+                    metrics_dict = _evaluate(y, y_pred, metrics)
+                    _save_labels(y_pred, f"{name}_DBSCAN_eps-{eps}_seed-{seed}.labels")
+                except Exception as exc:
+                    y_pred = []
+                    metrics_dict = {name: math.nan for name, _ in metrics}
+                    if verbose:
+                        print(f"DBSCAN falló en {name} (eps={eps}, seed={seed}): {exc}")
+                runtime = time.perf_counter() - start
+                record = {
+                    "dataset": name,
+                    "algorithm": "DBSCAN",
+                    "params": f"eps={eps}",
+                    "seed": seed,
+                    "runtime_sec": runtime,
+                }
+                record.update(metrics_dict)
+                results.append(record)
                 if verbose:
-                    print(f"DBSCAN falló en {name} (eps={eps}): {exc}")
-            runtime = time.perf_counter() - start
-            record = {
-                "dataset": name,
-                "algorithm": "DBSCAN",
-                "params": f"eps={eps}",
-                "runtime_sec": runtime,
-            }
-            record.update(metrics_dict)
-            results.append(record)
-            if verbose:
-                print(
-                    f"DBSCAN {name} eps={eps} → {runtime:.4f}s"
-                )
+                    print(
+                        f"DBSCAN {name} eps={eps} seed={seed} → {runtime:.4f}s",
+                    )
 
     df = pd.DataFrame(results)
     out_path = out_dir / "unsupervised_results.csv"
     df.to_csv(out_path, index=False)
+
+    summary = (
+        df.groupby(["dataset", "algorithm", "params"])
+        .agg(
+            {
+                "runtime_sec": ["mean", "std"],
+                "ARI": ["mean", "std"],
+                "homogeneity": ["mean", "std"],
+                "completeness": ["mean", "std"],
+                "v_measure": ["mean", "std"],
+            }
+        )
+    )
+    summary.columns = ["_".join(col).strip("_") for col in summary.columns.values]
+    summary.reset_index(inplace=True)
+    summary.to_csv(out_dir / "unsupervised_results_summary.csv", index=False)
+
     print(df.head())
     print(f"... guardado {len(df)} registros en {out_path}")
 
 
 if __name__ == "__main__":
-    run()
-
+    parser = argparse.ArgumentParser(description="Comparación de algoritmos no supervisados")
+    parser.add_argument("--runs", type=int, default=5, help="Número de repeticiones con distintas semillas")
+    parser.add_argument("--verbose", action="store_true", help="Mostrar progreso")
+    args = parser.parse_args()
+    run(verbose=args.verbose, seeds=list(range(args.runs)))

--- a/experiments/paper_experiments.py
+++ b/experiments/paper_experiments.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 
 from pathlib import Path
 import time
+from typing import Sequence
 
+import argparse
 import numpy as np
 import pandas as pd
 from sklearn.datasets import load_iris, load_wine, make_classification
@@ -40,7 +42,7 @@ def _save(df: pd.DataFrame, path: Path) -> None:
     df.to_csv(path, index=False)
 
 
-def supervised_comparison(out_dir: Path) -> pd.DataFrame:
+def supervised_comparison(out_dir: Path, seeds: Sequence[int]) -> pd.DataFrame:
     """Compare SheShe with supervised baselines.
 
     Datasets: Iris and Wine from scikit-learn.
@@ -53,111 +55,140 @@ def supervised_comparison(out_dir: Path) -> pd.DataFrame:
         "iris": load_iris(return_X_y=True),
         "wine": load_wine(return_X_y=True),
     }
-    algorithms = {
-        "LogReg": LogisticRegression(max_iter=500),
-        "KNN": KNeighborsClassifier(),
-        "RF": RandomForestClassifier(random_state=0),
-    }
     results = []
-    for dname, (X, y) in datasets.items():
-        Xtr, Xte, ytr, yte = train_test_split(
-            X, y, test_size=0.3, random_state=0, stratify=y
-        )
-        # Baselines
-        for aname, algo in algorithms.items():
-            start = time.perf_counter()
-            algo.fit(Xtr, ytr)
-            y_pred = algo.predict(Xte)
-            runtime = time.perf_counter() - start
-            acc = accuracy_score(yte, y_pred)
-            results.append(
-                {
-                    "dataset": dname,
-                    "algorithm": aname,
-                    "accuracy": acc,
-                    "runtime_sec": runtime,
-                }
+    for seed in seeds:
+        algos = {
+            "LogReg": LogisticRegression(max_iter=500, random_state=seed),
+            "KNN": KNeighborsClassifier(),
+            "RF": RandomForestClassifier(random_state=seed),
+        }
+        for dname, (X, y) in datasets.items():
+            Xtr, Xte, ytr, yte = train_test_split(
+                X, y, test_size=0.3, random_state=seed, stratify=y
             )
-        # SheShe
-        start = time.perf_counter()
-        sh = ModalBoundaryClustering(
-            base_estimator=LogisticRegression(max_iter=500),
-            task="classification",
-            random_state=0,
-        ).fit(Xtr, ytr)
-        y_pred = sh.predict(Xte)
-        runtime = time.perf_counter() - start
-        acc = accuracy_score(yte, y_pred)
-        results.append(
-            {
-                "dataset": dname,
-                "algorithm": "SheShe",
-                "accuracy": acc,
-                "runtime_sec": runtime,
-            }
-        )
-
-    df = pd.DataFrame(results)
-    _save(df, out_dir / "supervised_results.csv")
-
-    for dname in df["dataset"].unique():
-        subset = df[df["dataset"] == dname]
-        plt.figure()
-        plt.bar(subset["algorithm"], subset["accuracy"], color="tab:blue")
-        plt.ylim(0, 1)
-        plt.ylabel("Accuracy")
-        plt.title(f"Supervised comparison on {dname}")
-        plt.tight_layout()
-        plt.savefig(out_dir / f"{dname}_supervised.png")
-        plt.close()
-    return df
-
-
-def ablation_study(out_dir: Path) -> pd.DataFrame:
-    """Evaluate the effect of ``base_2d_rays`` and ``direction``.
-
-    Dataset: Iris.  Metric: accuracy.
-    """
-
-    X, y = load_iris(return_X_y=True)
-    Xtr, Xte, ytr, yte = train_test_split(
-        X, y, test_size=0.3, random_state=0, stratify=y
-    )
-    results = []
-    for rays in [4, 8, 12]:
-        for direction in ["center_out", "outside_in"]:
+            # Baselines
+            for aname, algo in algos.items():
+                start = time.perf_counter()
+                algo.fit(Xtr, ytr)
+                y_pred = algo.predict(Xte)
+                runtime = time.perf_counter() - start
+                acc = accuracy_score(yte, y_pred)
+                results.append(
+                    {
+                        "dataset": dname,
+                        "algorithm": aname,
+                        "seed": seed,
+                        "accuracy": acc,
+                        "runtime_sec": runtime,
+                    }
+                )
+            # SheShe
             start = time.perf_counter()
             sh = ModalBoundaryClustering(
-                base_estimator=LogisticRegression(max_iter=500),
+                base_estimator=LogisticRegression(max_iter=500, random_state=seed),
                 task="classification",
-                base_2d_rays=rays,
-                direction=direction,
-                random_state=0,
+                random_state=seed,
             ).fit(Xtr, ytr)
             y_pred = sh.predict(Xte)
             runtime = time.perf_counter() - start
             acc = accuracy_score(yte, y_pred)
             results.append(
                 {
-                    "base_2d_rays": rays,
-                    "direction": direction,
+                    "dataset": dname,
+                    "algorithm": "SheShe",
+                    "seed": seed,
                     "accuracy": acc,
                     "runtime_sec": runtime,
                 }
             )
+
+    df = pd.DataFrame(results)
+    _save(df, out_dir / "supervised_results.csv")
+
+    summary = (
+        df.groupby(["dataset", "algorithm"])
+        .agg({"accuracy": ["mean", "std"], "runtime_sec": ["mean", "std"]})
+    )
+    summary.columns = ["_".join(col).strip("_") for col in summary.columns.values]
+    summary.reset_index(inplace=True)
+    _save(summary, out_dir / "supervised_summary.csv")
+
+    for dname in summary["dataset"].unique():
+        subset = summary[summary["dataset"] == dname]
+        plt.figure()
+        plt.bar(
+            subset["algorithm"],
+            subset["accuracy_mean"],
+            yerr=subset["accuracy_std"],
+            capsize=4,
+            color="tab:blue",
+        )
+        plt.ylim(0, 1)
+        plt.ylabel("Accuracy")
+        plt.title(f"Supervised comparison on {dname}")
+        plt.tight_layout()
+        plt.savefig(out_dir / f"{dname}_supervised.png")
+        plt.close()
+    return summary
+
+
+def ablation_study(out_dir: Path, seeds: Sequence[int]) -> pd.DataFrame:
+    """Evaluate the effect of ``base_2d_rays`` and ``direction``.
+
+    Dataset: Iris.  Metric: accuracy.
+    """
+
+    X, y = load_iris(return_X_y=True)
+    results = []
+    for seed in seeds:
+        Xtr, Xte, ytr, yte = train_test_split(
+            X, y, test_size=0.3, random_state=seed, stratify=y
+        )
+        for rays in [4, 8, 12]:
+            for direction in ["center_out", "outside_in"]:
+                start = time.perf_counter()
+                sh = ModalBoundaryClustering(
+                    base_estimator=LogisticRegression(max_iter=500, random_state=seed),
+                    task="classification",
+                    base_2d_rays=rays,
+                    direction=direction,
+                    random_state=seed,
+                ).fit(Xtr, ytr)
+                y_pred = sh.predict(Xte)
+                runtime = time.perf_counter() - start
+                acc = accuracy_score(yte, y_pred)
+                results.append(
+                    {
+                        "base_2d_rays": rays,
+                        "direction": direction,
+                        "seed": seed,
+                        "accuracy": acc,
+                        "runtime_sec": runtime,
+                    }
+                )
     df = pd.DataFrame(results)
     _save(df, out_dir / "ablation_results.csv")
-    pivot = df.pivot(index="base_2d_rays", columns="direction", values="accuracy")
-    pivot.plot(kind="bar")
+
+    summary = (
+        df.groupby(["base_2d_rays", "direction"])
+        .agg({"accuracy": ["mean", "std"], "runtime_sec": ["mean", "std"]})
+    )
+    summary.columns = ["_".join(col).strip("_") for col in summary.columns.values]
+    summary.reset_index(inplace=True)
+    _save(summary, out_dir / "ablation_summary.csv")
+
+    pivot = summary.pivot(index="base_2d_rays", columns="direction", values="accuracy_mean")
+    err = summary.pivot(index="base_2d_rays", columns="direction", values="accuracy_std")
+    pivot.plot(kind="bar", yerr=err, capsize=4)
     plt.ylabel("Accuracy")
     plt.title("Ablation on Iris")
     plt.tight_layout()
     plt.savefig(out_dir / "ablation_accuracy.png")
     plt.close()
-    return df
+    return summary
 
 
-def sensitivity_analysis(out_dir: Path) -> pd.DataFrame:
+def sensitivity_analysis(out_dir: Path, seeds: Sequence[int]) -> pd.DataFrame:
     """Study sensitivity to dimensionality and noise.
 
     Uses synthetic datasets generated with ``make_classification`` and adds
@@ -165,41 +196,52 @@ def sensitivity_analysis(out_dir: Path) -> pd.DataFrame:
     """
 
     results = []
-    rng = np.random.default_rng(0)
-    for n_features in [2, 4, 8, 16]:
-        X, y = make_classification(
-            n_samples=400,
-            n_features=n_features,
-            n_informative=n_features // 2,
-            n_redundant=0,
-            n_clusters_per_class=1,
-            random_state=0,
-        )
-        for noise in [0.0, 0.3, 0.6]:
-            X_noisy = X + rng.normal(scale=noise, size=X.shape)
-            Xtr, Xte, ytr, yte = train_test_split(
-                X_noisy, y, test_size=0.3, random_state=0, stratify=y
+    for seed in seeds:
+        rng = np.random.default_rng(seed)
+        for n_features in [2, 4, 8, 16]:
+            X, y = make_classification(
+                n_samples=400,
+                n_features=n_features,
+                n_informative=n_features // 2,
+                n_redundant=0,
+                n_clusters_per_class=1,
+                random_state=seed,
             )
-            start = time.perf_counter()
-            sh = ModalBoundaryClustering(
-                base_estimator=LogisticRegression(max_iter=500),
-                task="classification",
-                random_state=0,
-            ).fit(Xtr, ytr)
-            y_pred = sh.predict(Xte)
-            runtime = time.perf_counter() - start
-            acc = accuracy_score(yte, y_pred)
-            results.append(
-                {
-                    "n_features": n_features,
-                    "noise": noise,
-                    "accuracy": acc,
-                    "runtime_sec": runtime,
-                }
-            )
+            for noise in [0.0, 0.3, 0.6]:
+                X_noisy = X + rng.normal(scale=noise, size=X.shape)
+                Xtr, Xte, ytr, yte = train_test_split(
+                    X_noisy, y, test_size=0.3, random_state=seed, stratify=y
+                )
+                start = time.perf_counter()
+                sh = ModalBoundaryClustering(
+                    base_estimator=LogisticRegression(max_iter=500, random_state=seed),
+                    task="classification",
+                    random_state=seed,
+                ).fit(Xtr, ytr)
+                y_pred = sh.predict(Xte)
+                runtime = time.perf_counter() - start
+                acc = accuracy_score(yte, y_pred)
+                results.append(
+                    {
+                        "n_features": n_features,
+                        "noise": noise,
+                        "seed": seed,
+                        "accuracy": acc,
+                        "runtime_sec": runtime,
+                    }
+                )
     df = pd.DataFrame(results)
     _save(df, out_dir / "sensitivity_results.csv")
-    pivot = df.pivot(index="n_features", columns="noise", values="accuracy")
+
+    summary = (
+        df.groupby(["n_features", "noise"])
+        .agg({"accuracy": ["mean", "std"], "runtime_sec": ["mean", "std"]})
+    )
+    summary.columns = ["_".join(col).strip("_") for col in summary.columns.values]
+    summary.reset_index(inplace=True)
+    _save(summary, out_dir / "sensitivity_summary.csv")
+
+    pivot = summary.pivot(index="n_features", columns="noise", values="accuracy_mean")
     plt.figure()
     im = plt.imshow(pivot, aspect="auto", origin="lower", cmap="viridis")
     plt.xticks(range(len(pivot.columns)), pivot.columns)
@@ -210,17 +252,21 @@ def sensitivity_analysis(out_dir: Path) -> pd.DataFrame:
     plt.tight_layout()
     plt.savefig(out_dir / "sensitivity_heatmap.png")
     plt.close()
-    return df
+    return summary
 
 
-def run_all(out_dir: Path | None = None) -> None:
+def run_all(out_dir: Path | None = None, seeds: Sequence[int] | None = None) -> None:
     out_dir = Path(out_dir or Path(__file__).parent.parent / "benchmark")
     out_dir.mkdir(parents=True, exist_ok=True)
-    supervised_comparison(out_dir)
-    ablation_study(out_dir)
-    sensitivity_analysis(out_dir)
+    seeds = list(seeds or range(5))
+    supervised_comparison(out_dir, seeds)
+    ablation_study(out_dir, seeds)
+    sensitivity_analysis(out_dir, seeds)
     print(f"Artifacts saved to {out_dir.resolve()}")
 
 
 if __name__ == "__main__":
-    run_all()
+    parser = argparse.ArgumentParser(description="Experimentos para el paper")
+    parser.add_argument("--runs", type=int, default=5, help="Número de repeticiones con distintas semillas")
+    args = parser.parse_args()
+    run_all(seeds=range(args.runs))


### PR DESCRIPTION
## Summary
- Add repeatable multi-seed runs and statistical summaries to compare_unsupervised.py and paper_experiments.py
- Document new --runs option and output summaries in experiments/README and project README
- Include new plotting examples demonstrating DataFrame usage and interpretability visualization

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ba6f21904832c85e4bfe8d8036748