### PR TITLE
Add 3D probability surface plotting utility

### DIFF
--- a/tests/test_plot_pair_3d.py
+++ b/tests/test_plot_pair_3d.py
@@ -1,0 +1,11 @@
+import matplotlib
+matplotlib.use('Agg')
+
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+
+def test_plot_pair_3d_runs():
+    X, y = load_iris(return_X_y=True)
+    sh = ModalBoundaryClustering(random_state=0).fit(X, y)
+    sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0])


### PR DESCRIPTION
## Summary
- add `plot_pair_3d` method to visualize class probability or regression values as a 3D surface
- test that `plot_pair_3d` runs on Iris dataset

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d43477d84832c804d7f6a045f0d0a