### PR TITLE
Allow supplying analytic gradient to gradient_ascent

### DIFF
--- a/tests/test_numeric_utils.py
+++ b/tests/test_numeric_utils.py
@@ -55,8 +55,11 @@ def test_gradient_ascent_quadratic_convergence():
     def f(x):
         return -((x[0] - 1.0) ** 2 + (x[1] + 2.0) ** 2)
 
+    def grad_f(x):
+        return np.array([-2.0 * (x[0] - 1.0), -2.0 * (x[1] + 2.0)])
+
     x0 = np.array([5.0, 5.0])
     lo = np.array([-10.0, -10.0])
     hi = np.array([10.0, 10.0])
-    res = gradient_ascent(f, x0, (lo, hi), lr=0.2, max_iter=500)
+    res = gradient_ascent(f, x0, (lo, hi), lr=0.2, max_iter=500, gradient=grad_f)
     assert np.allclose(res, np.array([1.0, -2.0]), atol=5e-2)


### PR DESCRIPTION
## Summary
- extend `gradient_ascent` with optional analytic gradient callback
- use supplied gradient in `_find_maximum` when available and update tests

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python - <<'PY'
import numpy as np, time
from sheshe.sheshe import gradient_ascent

def f(x):
    return -((x[0]-1.0)**2 + (x[1]+2.0)**2)

def grad_f(x):
    return np.array([-2.0*(x[0]-1.0), -2.0*(x[1]+2.0)])

x0=np.array([5.0,5.0])
lo=np.array([-10.0,-10.0])
hi=np.array([10.0,10.0])

start=time.time()
res_num=gradient_ascent(f,x0,(lo,hi),lr=0.2,max_iter=500)
num_time=time.time()-start

start=time.time()
res_ana=gradient_ascent(f,x0,(lo,hi),lr=0.2,max_iter=500,gradient=grad_f)
ana_time=time.time()-start

print('Numeric:',res_num,'time',num_time)
print('Analytic:',res_ana,'time',ana_time)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689d7ad66178832cbafb7bf018b682ae