### PR TITLE
Add persistence test and document ModalScoutEnsemble

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,29 @@ scout = SubspaceScout(
 subspaces = scout.fit(X, y)
 ```
 
+## ModalScoutEnsemble
+
+`ModalScoutEnsemble` trains multiple ModalBoundaryClustering models on the top subspaces returned by `SubspaceScout` and combines their predictions.
+
+```python
+from sheshe import ModalScoutEnsemble
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+mse = ModalScoutEnsemble(
+    base_estimator=LogisticRegression(max_iter=200),
+    task="classification",
+    random_state=0,
+    scout_kwargs={"max_order": 2, "top_m": 4, "sample_size": None},
+    cv=2,
+)
+mse.fit(X, y)
+print(mse.predict(X[:5]))
+```
+
 ### Experiments and benchmark
 
 The experiments comparing against **unsupervised** algorithms are located in

--- a/README_ES.md
+++ b/README_ES.md
@@ -209,6 +209,29 @@ scout = SubspaceScout(
 subspaces = scout.fit(X, y)
 ```
 
+## ModalScoutEnsemble
+
+`ModalScoutEnsemble` entrena varios modelos `ModalBoundaryClustering` en los mejores subespacios devueltos por `SubspaceScout` y combina sus predicciones.
+
+```python
+from sheshe import ModalScoutEnsemble
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+mse = ModalScoutEnsemble(
+    base_estimator=LogisticRegression(max_iter=200),
+    task="classification",
+    random_state=0,
+    scout_kwargs={"max_order": 2, "top_m": 4, "sample_size": None},
+    cv=2,
+)
+mse.fit(X, y)
+print(mse.predict(X[:5]))
+```
+
 ### Experimentos y benchmark
 
 Los experimentos de comparación con algoritmos **no supervisados** se encuentran

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,16 @@
+import numpy as np
+from pathlib import Path
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+
+def test_save_and_load(tmp_path: Path):
+    data = load_iris()
+    X, y = data.data, data.target
+    model = ModalBoundaryClustering(random_state=0).fit(X, y)
+    path = tmp_path / "mbc.joblib"
+    model.save(path)
+    assert path.exists()
+
+    loaded = ModalBoundaryClustering.load(path)
+    assert np.allclose(model.predict(X), loaded.predict(X))


### PR DESCRIPTION
## Summary
- add regression test for ModalBoundaryClustering.save/load to ensure persisted models reproduce predictions
- document ModalScoutEnsemble with usage examples in English and Spanish READMEs

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0183da6bc832c84f4d383ffcc2efc