### PR TITLE
docs: document ClusterRegion and add parameterized examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,20 @@ PYTHONPATH=src pytest -q
 
 ## Quick API
 
+The library exposes four main objects:
+
+- `ModalBoundaryClustering`
+- `ClusterRegion` – dataclass describing a discovered region
+- `SubspaceScout`
+- `ModalScoutEnsemble`
+
 ```python
-from sheshe import ModalBoundaryClustering
+from sheshe import (
+    ModalBoundaryClustering,
+    SubspaceScout,
+    ModalScoutEnsemble,
+    ClusterRegion,
+)
 
 # classification
 clf = ModalBoundaryClustering(
@@ -131,6 +143,27 @@ sh = ModalBoundaryClustering(
 
 sh.plot_pairs(X, y, max_pairs=2)
 plt.show()
+```
+
+### Classification — synthetic blobs with custom parameters
+```python
+from sklearn.datasets import make_blobs
+from sklearn.linear_model import LogisticRegression
+from sheshe import ModalBoundaryClustering
+
+X, y = make_blobs(n_samples=400, centers=5, cluster_std=1.8, random_state=0)
+
+sh = ModalBoundaryClustering(
+    base_estimator=LogisticRegression(max_iter=200),
+    task="classification",
+    base_2d_rays=16,
+    scan_steps=32,
+    n_max_seeds=3,
+    direction="outside_in",
+    random_state=0,
+).fit(X, y)
+
+print(sh.predict(X[:5]))
 ```
 
 ### Regression — Diabetes

--- a/README_ES.md
+++ b/README_ES.md
@@ -29,8 +29,20 @@ PYTHONPATH=src pytest -q
 
 ## API rápida
 
+La librería expone cuatro objetos principales:
+
+- `ModalBoundaryClustering`
+- `ClusterRegion` – dataclass con la información de cada región
+- `SubspaceScout`
+- `ModalScoutEnsemble`
+
 ```python
-from sheshe import ModalBoundaryClustering
+from sheshe import (
+    ModalBoundaryClustering,
+    SubspaceScout,
+    ModalScoutEnsemble,
+    ClusterRegion,
+)
 
 # clasificación
 clf = ModalBoundaryClustering(
@@ -126,6 +138,27 @@ sh = ModalBoundaryClustering(
 
 sh.plot_pairs(X, y, max_pairs=2)
 plt.show()
+```
+
+### Clasificación — blobs sintéticos con parámetros personalizados
+```python
+from sklearn.datasets import make_blobs
+from sklearn.linear_model import LogisticRegression
+from sheshe import ModalBoundaryClustering
+
+X, y = make_blobs(n_samples=400, centers=5, cluster_std=1.8, random_state=0)
+
+sh = ModalBoundaryClustering(
+    base_estimator=LogisticRegression(max_iter=200),
+    task="classification",
+    base_2d_rays=16,
+    scan_steps=32,
+    n_max_seeds=3,
+    direction="outside_in",
+    random_state=0,
+).fit(X, y)
+
+print(sh.predict(X[:5]))
 ```
 
 ### Regresión — Diabetes


### PR DESCRIPTION
## Summary
- Document all public classes including the ClusterRegion dataclass in the Quick API section
- Add a synthetic blob classification example with custom parameters
- Mirror these documentation improvements in the Spanish README

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0bef95a3c832cba7ac5740a467f20