### PR TITLE
feat: add smoothing option for inflection search

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ clf = ModalBoundaryClustering(
     direction="center_out",        # "center_out" | "outside_in"
     scan_radius_factor=3.0,
     scan_steps=24,
+    smooth_window=None,             # optional moving average window
     random_state=0
 )
 
@@ -88,9 +89,10 @@ reg = ModalBoundaryClustering(task="regression")
    - >3D: mixture of a few global directions + 2D/3D **subspaces**
 4. Along each ray, **scan radially** and compute the **first inflection point**
    according to `direction`:
-   - `center_out`: from the center outward
-   - `outside_in`: from the outside toward the center
-   Also record the **slope** (df/dt) at that point.
+    - `center_out`: from the center outward
+    - `outside_in`: from the outside toward the center
+   Optionally apply a moving average (`smooth_window`) and record the **slope**
+   (df/dt) at that point.
 5. Connect the inflection points to form the **boundary** of the region with
    high probability/value.
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -52,6 +52,7 @@ clf = ModalBoundaryClustering(
     direction="center_out",        # "center_out" | "outside_in"
     scan_radius_factor=3.0,
     scan_steps=64,
+    smooth_window=None,             # ventana de suavizado opcional
     random_state=0
 )
 
@@ -84,9 +85,10 @@ reg = ModalBoundaryClustering(task="regression")
    - 3D: ~26 direcciones (cobertura por *caps* esféricos con muestreo Fibonacci)
    - >3D: mezcla de unas pocas direcciones globales + **subespacios** 2D/3D
 4. Sobre cada rayo, **escanea radialmente** y calcula el **primer punto de inflexión** según `direction`:
-   - `center_out`: desde el centro hacia fuera
-   - `outside_in`: desde el exterior hacia el centro
-   Registra además la **pendiente** (df/dt) en ese punto.
+    - `center_out`: desde el centro hacia fuera
+    - `outside_in`: desde el exterior hacia el centro
+   Opcionalmente aplica un promedio móvil (`smooth_window`) y registra además la
+   **pendiente** (df/dt) en ese punto.
 5. Conecta los puntos de inflexión para formar la **frontera** de la región de alta probabilidad/valor.
 
 ---

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -47,6 +47,19 @@ def test_predict_regression_returns_base_estimator_value():
     assert np.allclose(y_hat, expected)
 
 
+def test_smooth_window_param():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    sh = ModalBoundaryClustering(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        random_state=0,
+        smooth_window=5,
+    )
+    sh.fit(X, y)
+    assert sh.smooth_window == 5
+
+
 def test_decision_function_classifier_and_fallback():
     iris = load_iris()
     X, y = iris.data, iris.target

--- a/tests/test_numeric_utils.py
+++ b/tests/test_numeric_utils.py
@@ -51,6 +51,17 @@ def test_find_inflection_outside_in():
     assert abs(slope) < 1e-3
 
 
+def test_find_inflection_with_smoothing():
+    ts = np.linspace(0, 3.0, 301)
+    base = 1.0 / (1.0 + ts**2)
+    noise = 0.05 * np.sin(40 * ts)
+    vals = base + noise
+    t_expected = 1.0 / math.sqrt(3.0)
+    t_raw, _ = find_inflection(ts, vals, "center_out")
+    t_smooth, _ = find_inflection(ts, vals, "center_out", smooth_window=11)
+    assert abs(t_smooth - t_expected) < abs(t_raw - t_expected)
+
+
 def test_gradient_ascent_quadratic_convergence():
     def f(x):
         return -((x[0] - 1.0) ** 2 + (x[1] + 2.0) ** 2)


### PR DESCRIPTION
## Summary
- add `smooth_window` parameter to ModalBoundaryClustering and `find_inflection`
- allow optional moving-average smoothing before second derivative
- document new parameter and add corresponding tests

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d14e8b88832c8599211bebb3c47a