### PR TITLE
Add configurable radius drop for inflection fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ clf = ModalBoundaryClustering(
     scan_radius_factor=3.0,
     scan_steps=24,
     smooth_window=None,             # optional moving average window
+    drop_fraction=0.5,              # fallback drop from peak value
     random_state=0
 )
 
@@ -92,7 +93,8 @@ reg = ModalBoundaryClustering(task="regression")
     - `center_out`: from the center outward
     - `outside_in`: from the outside toward the center
    Optionally apply a moving average (`smooth_window`) and record the **slope**
-   (df/dt) at that point.
+   (df/dt) at that point. If no inflection is found, use the first point where
+   the value drops below `drop_fraction` of the peak.
 5. Connect the inflection points to form the **boundary** of the region with
    high probability/value.
 
@@ -114,6 +116,7 @@ sh = ModalBoundaryClustering(
     task="classification",
     base_2d_rays=8,
     random_state=0,
+    drop_fraction=0.5,
 ).fit(X, y)
 
 print(sh.interpretability_summary(iris.feature_names).head())
@@ -141,6 +144,7 @@ sh = ModalBoundaryClustering(
     task="classification",
     base_2d_rays=8,
     random_state=0,
+    drop_fraction=0.5,
 ).fit(X, y)
 
 sh.plot_pairs(X, y, max_pairs=2)
@@ -163,6 +167,7 @@ sh = ModalBoundaryClustering(
     n_max_seeds=3,
     direction="outside_in",
     random_state=0,
+    drop_fraction=0.5,
 ).fit(X, y)
 
 print(sh.predict(X[:5]))
@@ -183,6 +188,7 @@ sh = ModalBoundaryClustering(
     task="regression",
     base_2d_rays=8,
     random_state=0,
+    drop_fraction=0.5,
 ).fit(X, y)
 
 print(sh.interpretability_summary(diab.feature_names).head())

--- a/README_ES.md
+++ b/README_ES.md
@@ -53,6 +53,7 @@ clf = ModalBoundaryClustering(
     scan_radius_factor=3.0,
     scan_steps=64,
     smooth_window=None,             # ventana de suavizado opcional
+    drop_fraction=0.5,              # caída requerida desde el pico
     random_state=0
 )
 
@@ -88,7 +89,9 @@ reg = ModalBoundaryClustering(task="regression")
     - `center_out`: desde el centro hacia fuera
     - `outside_in`: desde el exterior hacia el centro
    Opcionalmente aplica un promedio móvil (`smooth_window`) y registra además la
-   **pendiente** (df/dt) en ese punto.
+   **pendiente** (df/dt) en ese punto. Si no se detecta un punto de inflexión,
+   usa el primer valor donde la función cae por debajo de `drop_fraction` del
+   máximo.
 5. Conecta los puntos de inflexión para formar la **frontera** de la región de alta probabilidad/valor.
 
 ---
@@ -109,6 +112,7 @@ sh = ModalBoundaryClustering(
     task="classification",
     base_2d_rays=8,
     random_state=0,
+    drop_fraction=0.5,
 ).fit(X, y)
 
 print(sh.interpretability_summary(iris.feature_names).head())
@@ -136,6 +140,7 @@ sh = ModalBoundaryClustering(
     task="classification",
     base_2d_rays=8,
     random_state=0,
+    drop_fraction=0.5,
 ).fit(X, y)
 
 sh.plot_pairs(X, y, max_pairs=2)
@@ -158,6 +163,7 @@ sh = ModalBoundaryClustering(
     n_max_seeds=3,
     direction="outside_in",
     random_state=0,
+    drop_fraction=0.5,
 ).fit(X, y)
 
 print(sh.predict(X[:5]))
@@ -178,6 +184,7 @@ sh = ModalBoundaryClustering(
     task="regression",
     base_2d_rays=8,
     random_state=0,
+    drop_fraction=0.5,
 ).fit(X, y)
 
 print(sh.interpretability_summary(diab.feature_names).head())

--- a/examples/demo_classification.py
+++ b/examples/demo_classification.py
@@ -20,7 +20,11 @@ def main():
     for name, est in models.items():
         print(f"\n-- {name} --")
         sh = ModalBoundaryClustering(
-            base_estimator=est, task="classification", base_2d_rays=8, random_state=0
+            base_estimator=est,
+            task="classification",
+            base_2d_rays=8,
+            random_state=0,
+            drop_fraction=0.5,
         ).fit(X, y)
         y_hat = sh.predict(X)
         print("Accuracy:", accuracy_score(y, y_hat))
@@ -32,7 +36,10 @@ def main():
     Xw, yw = wine.data, wine.target
     sh = ModalBoundaryClustering(
         base_estimator=RandomForestClassifier(n_estimators=350, random_state=1),
-        task="classification", base_2d_rays=8, random_state=1
+        task="classification",
+        base_2d_rays=8,
+        random_state=1,
+        drop_fraction=0.5,
     ).fit(Xw, yw)
     print("Accuracy Wine:", accuracy_score(yw, sh.predict(Xw)))
     print(sh.interpretability_summary(wine.feature_names).head())

--- a/examples/demo_regression.py
+++ b/examples/demo_regression.py
@@ -16,7 +16,11 @@ def main():
     for name, est in models.items():
         print(f"\n-- {name} --")
         sh = ModalBoundaryClustering(
-            base_estimator=est, task="regression", base_2d_rays=8, random_state=0
+            base_estimator=est,
+            task="regression",
+            base_2d_rays=8,
+            random_state=0,
+            drop_fraction=0.5,
         ).fit(Xd, yd)
         seg = sh.predict(Xd).mean()
         yhat = sh.pipeline_.predict(Xd)
@@ -27,7 +31,13 @@ def main():
     print("\n=== Friedman1 ===")
     Xf, yf = make_friedman1(n_samples=800, n_features=8, noise=0.5, random_state=0)
     est = GradientBoostingRegressor(random_state=0)
-    sh = ModalBoundaryClustering(est, task="regression", base_2d_rays=8, random_state=1).fit(Xf, yf)
+    sh = ModalBoundaryClustering(
+        est,
+        task="regression",
+        base_2d_rays=8,
+        random_state=1,
+        drop_fraction=0.5,
+    ).fit(Xf, yf)
     print("Zona alta (Friedman1):", sh.predict(Xf).mean())
     sh.plot_pairs(Xf, max_pairs=3)
 

--- a/examples/iris_visualization.py
+++ b/examples/iris_visualization.py
@@ -21,6 +21,7 @@ def main() -> None:
         task="classification",
         base_2d_rays=8,  # número de rayos por cada plano 2D considerado
         random_state=0,
+        drop_fraction=0.5,
     ).fit(X, y)
 
     # Create up to two pairwise plots

--- a/examples/save_load_demo.py
+++ b/examples/save_load_demo.py
@@ -8,7 +8,7 @@ def main():
     iris = load_iris()
     X, y = iris.data, iris.target
 
-    model = ModalBoundaryClustering(random_state=0).fit(X, y)
+    model = ModalBoundaryClustering(random_state=0, drop_fraction=0.5).fit(X, y)
     path = Path("sheshe_model.joblib")
     model.save(path)
     loaded = ModalBoundaryClustering.load(path)

--- a/examples/titanic_demo.py
+++ b/examples/titanic_demo.py
@@ -13,7 +13,10 @@ def main():
 
     sh = ModalBoundaryClustering(
         base_estimator=LogisticRegression(max_iter=1000),
-        task="classification", base_2d_rays=8, random_state=2
+        task="classification",
+        base_2d_rays=8,
+        random_state=2,
+        drop_fraction=0.5,
     ).fit(X, y)
     print("Accuracy Titanic:", accuracy_score(y, sh.predict(X)))
     print(sh.interpretability_summary(df.drop(columns=["survived"]).columns.tolist()).head())

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -175,3 +175,25 @@ def test_fit_raises_with_single_class():
     sh = ModalBoundaryClustering(task="classification")
     with pytest.raises(ValueError, match="at least two classes"):
         sh.fit(X, y)
+
+
+def test_drop_fraction_changes_radii():
+    center = np.array([0.0])
+    dirs = np.array([[1.0]])
+    X_std = np.array([1.0])
+
+    def f(point):
+        return np.exp(-point[0])
+
+    lo = np.array([0.0])
+    hi = np.array([10.0])
+
+    sh1 = ModalBoundaryClustering(drop_fraction=0.5)
+    sh1.bounds_ = (lo, hi)
+    r1, _, _ = sh1._scan_radii(center, f, dirs, X_std)
+
+    sh2 = ModalBoundaryClustering(drop_fraction=0.2)
+    sh2.bounds_ = (lo, hi)
+    r2, _, _ = sh2._scan_radii(center, f, dirs, X_std)
+
+    assert r2[0] > r1[0]


### PR DESCRIPTION
## Summary
- allow specifying `drop_fraction` in `ModalBoundaryClustering`
- tune `find_inflection` to use the configured drop fraction
- document drop fraction and add regression tests

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d399f224832c92d81d6dc6c9319e