### PR TITLE
Add benchmarked percentile stop criterion documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ clf = ModalBoundaryClustering(
     scan_steps=24,
     smooth_window=None,             # optional moving average window
     drop_fraction=0.5,              # fallback drop from peak value
+    stop_criteria="inflexion",     # or "percentile" for decile drop
     random_state=0
 )
 
@@ -89,12 +90,14 @@ reg = ModalBoundaryClustering(task="regression")
    - 3D: ~26 directions (coverage by spherical *caps* using Fibonacci sampling)
    - >3D: mixture of a few global directions + 2D/3D **subspaces**
 4. Along each ray, **scan radially** and compute the **first inflection point**
-   according to `direction`:
+   according to `direction` and `stop_criteria`:
     - `center_out`: from the center outward
     - `outside_in`: from the outside toward the center
    Optionally apply a moving average (`smooth_window`) and record the **slope**
-   (df/dt) at that point. If no inflection is found, use the first point where
-   the value drops below `drop_fraction` of the peak.
+   (df/dt) at that point. With `stop_criteria="percentile"` the scan stops
+   when the value falls to a lower decile of the dataset distribution. If no
+   stop is found, use the first point where the value drops below
+   `drop_fraction` of the peak.
 5. Connect the inflection points to form the **boundary** of the region with
    high probability/value.
 
@@ -195,6 +198,27 @@ print(sh.interpretability_summary(diab.feature_names).head())
 sh.plot_pairs(X, max_pairs=3)
 plt.show()
 ```
+
+---
+
+## Benchmark
+
+The percentile-based stopping rule avoids the point of inflection and scans
+only until the value crosses into a lower decile.  The optimized loop
+implementation is considerably faster than the previous vectorized version. On
+the Iris dataset:
+
+```
+$ PYTHONPATH=src python experiments/benchmark_stop_criteria.py
+vectorized implementation: 0.0259s
+loop implementation:       0.0121s
+speedup: 2.14x
+ModalBoundaryClustering fit with stop_criteria='inflexion': 0.1026s
+ModalBoundaryClustering fit with stop_criteria='percentile': 0.1411s
+```
+
+The exact numbers depend on the machine, but the optimized loop method is
+substantially quicker while producing the same results.
 
 ### Saving figures
 ```python

--- a/experiments/benchmark_stop_criteria.py
+++ b/experiments/benchmark_stop_criteria.py
@@ -1,0 +1,95 @@
+"""Benchmark stop criteria implementations.
+
+This script compares the previous vectorized implementation of
+``find_percentile_drop`` with the current optimized loop version.  It also
+measures the overall fitting time of :class:`ModalBoundaryClustering` when using
+the ``inflection`` and ``percentile`` stop criteria.
+
+Run with ``PYTHONPATH=src python experiments/benchmark_stop_criteria.py``.
+"""
+
+import time
+import numpy as np
+from sklearn.datasets import load_iris
+
+from sheshe.sheshe import ModalBoundaryClustering, find_percentile_drop
+
+
+def _vectorized_find_percentile_drop(ts, vals, direction, deciles, drop_fraction=0.5):
+    """Vectorized version used previously (kept here for benchmarking)."""
+    if direction == "outside_in":
+        ts_scan = ts[::-1]
+        vals_scan = vals[::-1]
+    else:
+        ts_scan = ts
+        vals_scan = vals
+
+    dec_idx = np.searchsorted(deciles, vals_scan, side="right") - 1
+    dec_drops = np.where(np.diff(dec_idx) < 0)[0]
+
+    if dec_drops.size > 0:
+        idx = int(dec_drops[0] + 1)
+        t_scan = ts_scan[idx]
+        m_scan = (vals_scan[idx] - vals_scan[idx - 1]) / (
+            ts_scan[idx] - ts_scan[idx - 1] + 1e-12
+        )
+    else:
+        target = vals_scan[0] * drop_fraction
+        t_scan = ts_scan[-1]
+        m_scan = (vals_scan[-1] - vals_scan[0]) / (
+            ts_scan[-1] - ts_scan[0] + 1e-12
+        )
+        for j in range(1, len(vals_scan)):
+            if vals_scan[j] <= target:
+                t0, t1 = ts_scan[j - 1], ts_scan[j]
+                v0, v1 = vals_scan[j - 1], vals_scan[j]
+                alpha = float(
+                    np.clip((target - v0) / (v1 - v0 + 1e-12), 0.0, 1.0)
+                )
+                t_scan = t0 + alpha * (t1 - t0)
+                m_scan = (v1 - v0) / (t1 - t0 + 1e-12)
+                break
+
+    t_abs = t_scan if direction == "center_out" else (ts[-1] - t_scan)
+    return float(t_abs), float(m_scan)
+
+
+def benchmark_functions():
+    rng = np.random.default_rng(0)
+    ts = np.linspace(0, 5, 500)
+    vals = np.linspace(1.0, 0.0, 500) + rng.normal(scale=0.01, size=500)
+    deciles = np.linspace(0.0, 1.0, 11)
+    reps = 2000
+
+    t0 = time.time()
+    for _ in range(reps):
+        _vectorized_find_percentile_drop(ts, vals, "center_out", deciles)
+    t_vec = time.time() - t0
+
+    t0 = time.time()
+    for _ in range(reps):
+        find_percentile_drop(ts, vals, "center_out", deciles)
+    t_loop = time.time() - t0
+
+    res_old = _vectorized_find_percentile_drop(ts, vals, "center_out", deciles)
+    res_new = find_percentile_drop(ts, vals, "center_out", deciles)
+    assert np.allclose(res_old, res_new)
+
+    print(f"vectorized implementation: {t_vec:.4f}s")
+    print(f"loop implementation:       {t_loop:.4f}s")
+    if t_loop > 0:
+        print(f"speedup: {t_vec / t_loop:.2f}x")
+
+
+def benchmark_model_fit():
+    X, y = load_iris(return_X_y=True)
+    for crit in ("inflexion", "percentile"):
+        sh = ModalBoundaryClustering(task="classification", stop_criteria=crit, random_state=0)
+        t0 = time.time(); sh.fit(X, y); t = time.time() - t0
+        print(f"ModalBoundaryClustering fit with stop_criteria='{crit}': {t:.4f}s")
+
+
+if __name__ == "__main__":
+    benchmark_functions()
+    benchmark_model_fit()
+

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -197,3 +197,27 @@ def test_drop_fraction_changes_radii():
     r2, _, _ = sh2._scan_radii(center, f, dirs, X_std)
 
     assert r2[0] > r1[0]
+
+
+def test_percentile_stop_criteria():
+    center = np.array([0.0])
+    dirs = np.array([[1.0]])
+    X_std = np.array([1.0])
+
+    def f(point):
+        return 0.94 - 0.02 * point[0]
+
+    def f_batch(X):
+        return 0.94 - 0.02 * X[:, 0]
+
+    f.batch = f_batch  # type: ignore[attr-defined]
+
+    lo = np.array([0.0])
+    hi = np.array([10.0])
+
+    deciles = np.array([0, 0.1, 0.2, 0.3, 0.4, 0.9, 0.92, 0.93, 0.94, 0.94, 1.0])
+
+    sh = ModalBoundaryClustering(scan_steps=3, scan_radius_factor=2.0, stop_criteria="percentile")
+    sh.bounds_ = (lo, hi)
+    r, _, _ = sh._scan_radii(center, f, dirs, X_std, deciles=deciles)
+    assert np.isclose(r[0], 1.0)


### PR DESCRIPTION
## Summary
- streamline `find_percentile_drop` with inline decile search for faster scans
- document `stop_criteria` usage and add benchmark script with results
- provide README updates in English and Spanish

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python experiments/benchmark_stop_criteria.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0d819ee0c832cadb3e5cffc04b33c