### PR TITLE
Add cluster IDs across ModalBoundaryClustering and ModalScoutEnsemble

### DIFF
--- a/src/sheshe/modal_scout_ensemble.py
+++ b/src/sheshe/modal_scout_ensemble.py
@@ -419,6 +419,16 @@ class ModalScoutEnsemble(BaseEstimator):
         c = np.unique(y)
       self.classes_ = c
 
+    # 9) Assign global cluster IDs across all submodels
+    self.regions_ = []
+    cid = 0
+    for mbc in self.models_:
+      if hasattr(mbc, "regions_"):
+        for reg in mbc.regions_:
+          reg.cluster_id = cid
+          self.regions_.append(reg)
+          cid += 1
+
     if self.verbose:
       print(f"[ModalScoutEnsemble] Submodelos={len(self.models_)} | Pesos≈{np.round(self.weights_, 3)}")
     return self
@@ -480,6 +490,7 @@ class ModalScoutEnsemble(BaseEstimator):
         "cv_score": float(self.cv_scores_[idx]) if idx < len(self.cv_scores_) else None,
         "feat_importance": float(self.imp_scores_[idx]) if idx < len(self.imp_scores_) else None,
         "weight": float(w),
+        "cluster_ids": [reg.cluster_id for reg in getattr(mbc, "regions_", [])],
       }
       for attr in ("regions_", "rules_", "segments_", "boundaries_", "feature_importances_"):
         if hasattr(mbc, attr):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -17,7 +17,7 @@ def test_import_and_fit():
     proba = sh.predict_proba(X[:3])
     assert proba.shape[0] == 3
     df = sh.interpretability_summary(iris.feature_names)
-    assert {"Tipo","Distancia","Categoria"}.issubset(df.columns)
+    assert {"Tipo","Distancia","Categoria","ClusterID"}.issubset(df.columns)
     score = sh.score(X, y)
     assert 0.0 <= score <= 1.0
 


### PR DESCRIPTION
## Summary
- Assign a unique `cluster_id` to each ClusterRegion in ModalBoundaryClustering
- Propagate global cluster identifiers through ModalScoutEnsemble and reports
- Expose cluster IDs in interpretability summaries and plotting utilities

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef93975c832cab8e0601e0049869