### PR TITLE
Document report method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,47 @@ mse.fit(X, y)
 print(mse.predict(X[:5]))
 ```
 
+#### `report()`
+
+`report()` returns a list with one entry per trained subspace, sorted by
+`weight`. Each entry is a dictionary containing:
+
+- `features`: tuple with the indices of the features in that subspace.
+- `order`: number of features (subspace order).
+- `scout_score`: score assigned by `SubspaceScout`.
+- `cv_score`: cross-validation score of the submodel.
+- `feat_importance`: mean feature importance for the subspace.
+- `weight`: normalized weight used by the ensemble.
+
+Example:
+
+```python
+from pprint import pprint
+
+summary = mse.report()
+pprint([
+    {k: row[k] for k in ("features", "order", "scout_score", "cv_score", "feat_importance", "weight")}
+    for row in summary[:2]
+])
+```
+
+Output:
+
+```text
+[{'cv_score': 0.9267,
+  'feat_importance': 5.9886,
+  'features': (3, 1),
+  'order': 2,
+  'scout_score': -0.2368,
+  'weight': 0.4336},
+ {'cv_score': 0.8467,
+  'feat_importance': 7.3800,
+  'features': (2, 1),
+  'order': 2,
+  'scout_score': -0.1543,
+  'weight': 0.4193}]
+```
+
 ### Experiments and benchmark
 
 The experiments comparing against **unsupervised** algorithms are located in

--- a/README_ES.md
+++ b/README_ES.md
@@ -299,6 +299,47 @@ mse.fit(X, y)
 print(mse.predict(X[:5]))
 ```
 
+#### `report()`
+
+`report()` devuelve una lista con un elemento por cada subespacio entrenado,
+ordenada por `weight`. Cada elemento es un diccionario con:
+
+- `features`: tupla con los índices de las características del subespacio.
+- `order`: número de características del subespacio.
+- `scout_score`: puntuación asignada por `SubspaceScout`.
+- `cv_score`: puntuación de validación cruzada del submodelo.
+- `feat_importance`: importancia media de las características.
+- `weight`: peso normalizado en el ensamble.
+
+Ejemplo:
+
+```python
+from pprint import pprint
+
+resumen = mse.report()
+pprint([
+    {k: row[k] for k in ("features", "order", "scout_score", "cv_score", "feat_importance", "weight")}
+    for row in resumen[:2]
+])
+```
+
+Salida:
+
+```text
+[{'cv_score': 0.9267,
+  'feat_importance': 5.9886,
+  'features': (3, 1),
+  'order': 2,
+  'scout_score': -0.2368,
+  'weight': 0.4336},
+ {'cv_score': 0.8467,
+  'feat_importance': 7.3800,
+  'features': (2, 1),
+  'order': 2,
+  'scout_score': -0.1543,
+  'weight': 0.4193}]
+```
+
 ### Experimentos y benchmark
 
 Los experimentos de comparación con algoritmos **no supervisados** se encuentran


### PR DESCRIPTION
## Summary
- Describe ModalScoutEnsemble.report structure and output in README
- Add Spanish translation of report() documentation in README_ES

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f2810138832ca6b0914a0ac59c64