### PR TITLE
docs: document predict_proba for ModalScoutEnsemble

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,16 @@ mse.fit(X, y)
 print(mse.predict(X[:5]))
 ```
 
+#### `predict_proba(X)`
+
+Only available for classification tasks, this method returns the weighted mixture
+of class probabilities from all submodels in the ensemble.
+
+```python
+mse.fit(X, y)
+print(mse.predict_proba(X[:5]))
+```
+
 #### `report()`
 
 `report()` returns a list with one entry per trained subspace, sorted by


### PR DESCRIPTION
## Summary
- document `predict_proba(X)` for ModalScoutEnsemble, noting classification-only support and weighted mixture of submodel probabilities
- provide example of calling `predict_proba` after fitting the ensemble

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sheshe')*

------
https://chatgpt.com/codex/tasks/task_e_68a0f552dfac832cb76c92be12587e20