### PR TITLE
Add hnswlib to dev extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "matplotlib",
     ],
     extras_require={
-        "dev": ["pytest", "seaborn"],
+        "dev": ["pytest", "seaborn", "hnswlib"],
     },
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
- align `setup.py` dev extras with `requirements-dev.txt` by including `hnswlib`

## Testing
- `pip install -e .[dev]` (fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)
- `pytest` (fails: ModuleNotFoundError: No module named 'sheshe')

------
https://chatgpt.com/codex/tasks/task_e_68a0ed9abad4832cbc799683ee3ef5e2