### PR TITLE
Add labels_ attribute for clustering compatibility

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -885,6 +885,14 @@ class ModalBoundaryClustering(BaseEstimator):
                     inflection_points=infl, inflection_slopes=slopes,
                     peak_value_real=peak_real, peak_value_norm=peak_norm
                 ))
+            # Guardar etiquetas de entrenamiento para compatibilidad con
+            # la API estándar de clustering de scikit-learn
+            save_flag = self.save_labels
+            self.save_labels = False
+            try:
+                self.labels_ = self.predict(X)
+            finally:
+                self.save_labels = save_flag
         except Exception as exc:
             self._log(f"Error in fit: {exc}")
             raise

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -22,6 +22,34 @@ def test_import_and_fit():
     assert 0.0 <= score <= 1.0
 
 
+def test_labels_attribute_after_fit():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    sh = ModalBoundaryClustering(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        random_state=0,
+    )
+    sh.fit(X, y)
+    assert hasattr(sh, "labels_")
+    assert sh.labels_.shape[0] == X.shape[0]
+    assert np.array_equal(sh.labels_, sh.predict(X))
+
+
+def test_fit_predict_sets_labels_attribute():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    sh = ModalBoundaryClustering(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        random_state=0,
+    )
+    labels = sh.fit_predict(X, y)
+    assert hasattr(sh, "labels_")
+    assert np.array_equal(labels, sh.predict(X))
+    assert np.array_equal(sh.labels_, labels)
+
+
 def test_score_regression():
     X, y = make_regression(n_samples=100, n_features=4, noise=0.1, random_state=0)
     sh = ModalBoundaryClustering(


### PR DESCRIPTION
## Summary
- cache training labels in `ModalBoundaryClustering.labels_` after fitting
- call `predict` in `fit_predict` rather than returning cached labels directly
- test that `labels_` is set after `fit_predict`

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0f84a25b0832c9487afe8917a8e75