### PR TITLE
Add region membership predictions

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -891,6 +891,7 @@ class ModalBoundaryClustering(BaseEstimator):
             self.save_labels = False
             try:
                 self.labels_ = self.predict(X)
+                self.labels2_ = self.predict_regions(X)
             finally:
                 self.save_labels = save_flag
         except Exception as exc:
@@ -990,6 +991,47 @@ class ModalBoundaryClustering(BaseEstimator):
             raise
         runtime = time.perf_counter() - start
         self._log(f"predict completed in {runtime:.4f}s")
+        self._maybe_save_labels(result, label_path)
+        return result
+
+    def predict_regions(
+        self,
+        X: Union[np.ndarray, pd.DataFrame],
+        label_path: Optional[Union[str, Path]] = None,
+    ) -> np.ndarray:
+        """Region membership prediction for ``X``.
+
+        For each sample the method returns:
+
+        - ``-1`` if the sample does not fall inside any region.
+        - The ``cluster_id`` of the region if it falls in exactly one.
+        - A list with all ``cluster_id`` values when the sample belongs to
+          multiple regions.
+
+        This method ignores the base estimator and solely relies on the
+        discovered regions.
+        """
+        start = time.perf_counter()
+        try:
+            check_is_fitted(self, "regions_")
+            X = np.asarray(X, dtype=float)
+            M = self._membership_matrix(X)
+            ids = np.array([reg.cluster_id for reg in self.regions_])
+            pred: np.ndarray = np.empty(len(X), dtype=object)
+            for i in range(len(X)):
+                ks = np.where(M[i] == 1)[0]
+                if len(ks) == 0:
+                    pred[i] = -1
+                elif len(ks) == 1:
+                    pred[i] = ids[ks[0]]
+                else:
+                    pred[i] = ids[ks].tolist()
+            result = pred
+        except Exception as exc:
+            self._log(f"Error in predict_regions: {exc}")
+            raise
+        runtime = time.perf_counter() - start
+        self._log(f"predict_regions completed in {runtime:.4f}s")
         self._maybe_save_labels(result, label_path)
         return result
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -50,6 +50,26 @@ def test_fit_predict_sets_labels_attribute():
     assert np.array_equal(sh.labels_, labels)
 
 
+def test_labels2_attribute_and_method():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    sh = ModalBoundaryClustering(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        random_state=0,
+    )
+    sh.fit(X, y)
+    assert hasattr(sh, "labels2_")
+    assert sh.labels2_.shape[0] == X.shape[0]
+    # calling predict_regions should match labels2_
+    expected = sh.predict_regions(X)
+    assert np.array_equal(sh.labels2_, expected)
+    # sample far away from training data should be marked as -1
+    far_point = np.array([[1000, 1000, 1000, 1000]])
+    far_label = sh.predict_regions(far_point)[0]
+    assert far_label == -1
+
+
 def test_score_regression():
     X, y = make_regression(n_samples=100, n_features=4, noise=0.1, random_state=0)
     sh = ModalBoundaryClustering(


### PR DESCRIPTION
## Summary
- expose region membership predictions via `predict_regions` and `labels2_`
- verify new behaviour with unit test

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ff5fc314832cab3a55f0d6cf278b