### PR TITLE
Docs: mention supervised clustering in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,14 @@
 
 Edge segmentation and hyperboundary exploration based on **local maxima** of
 the **class probability** (classification) or the **predicted value**
-(regression).
+(regression). It is a supervised clustering algorithm.
+
+Unlike traditional unsupervised clustering methods that rely only on feature
+similarity, SheShe learns from labeled examples. A base estimator models the
+relationship between inputs and targets, and the algorithm discovers regions
+whose responses remain consistently high for a given class or target value.
+Clusters therefore follow the supervised decision surface instead of arbitrary
+distance metrics.
 
 ---
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -3,6 +3,14 @@
 
 Segmentación de bordes y exploración de hiper-fronteras basada en **máximos locales** de
 la **probabilidad por clase** (clasificación) o del **valor predicho** (regresión).
+Se trata de un algoritmo de clustering supervisado.
+
+A diferencia de los métodos de clustering no supervisados que dependen solo de
+la similitud entre características, SheShe aprovecha ejemplos etiquetados. Un
+estimador base modela la relación entre entradas y objetivos, y el algoritmo
+descubre regiones cuyas respuestas se mantienen altas para una clase o valor.
+Los clusters siguen así la superficie de decisión supervisada en lugar de
+métricas de distancia arbitrarias.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that SheShe is a supervised clustering algorithm in both English and Spanish READMEs
- explain how labels guide region discovery and why the approach differs from unsupervised clustering

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a102d2c440832caeb670b75012cf0f