### PR TITLE
Add cluster lookup by id

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -1035,6 +1035,25 @@ class ModalBoundaryClustering(BaseEstimator):
         self._maybe_save_labels(result, label_path)
         return result
 
+    def get_cluster(self, cluster_id: int) -> Optional[ClusterRegion]:
+        """Return the :class:`ClusterRegion` with the given ``cluster_id``.
+
+        Parameters
+        ----------
+        cluster_id : int
+            Identifier of the cluster to retrieve.
+
+        Returns
+        -------
+        ClusterRegion or None
+            Cluster object matching ``cluster_id`` or ``None`` if not found.
+        """
+        check_is_fitted(self, "regions_")
+        for reg in self.regions_:
+            if reg.cluster_id == cluster_id:
+                return reg
+        return None
+
     def predict_proba(self, X: Union[np.ndarray, pd.DataFrame]) -> np.ndarray:
         """Classification: class probabilities or decision scores.
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -269,3 +269,18 @@ def test_percentile_stop_criteria():
     sh.bounds_ = (lo, hi)
     r, _, _ = sh._scan_radii(center, f, dirs, X_std, deciles=deciles)
     assert np.isclose(r[0], 1.0)
+
+
+def test_get_cluster_by_id():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    sh = ModalBoundaryClustering(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        random_state=0,
+    )
+    sh.fit(X, y)
+    first = sh.regions_[0]
+    found = sh.get_cluster(first.cluster_id)
+    assert found is first
+    assert sh.get_cluster(-1) is None


### PR DESCRIPTION
## Summary
- add `get_cluster` method to retrieve cluster region by id
- cover cluster lookup with unit tests

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a10dfbd16c832c93854fe4bf34ee28