### PR TITLE
Make label2 optional

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -495,6 +495,7 @@ class ModalBoundaryClustering(BaseEstimator):
         max_subspaces: int = 20,
         verbose: bool = False,
         save_labels: bool = False,
+        save_label2: bool = False,
         out_dir: Optional[Union[str, Path]] = None,
         auto_rays_by_dim: bool = True,
         use_spsa: bool = False,
@@ -535,6 +536,7 @@ class ModalBoundaryClustering(BaseEstimator):
         self.max_subspaces = max_subspaces
         self.verbose = verbose
         self.save_labels = save_labels
+        self.save_label2 = save_label2
         self.out_dir = Path(out_dir) if out_dir is not None else None
         self.auto_rays_by_dim = auto_rays_by_dim
         self.use_spsa = use_spsa
@@ -891,7 +893,8 @@ class ModalBoundaryClustering(BaseEstimator):
             self.save_labels = False
             try:
                 self.labels_ = self.predict(X)
-                self.labels2_ = self.predict_regions(X)
+                if self.save_label2:
+                    self.labels2_ = self.predict_regions(X)
             finally:
                 self.save_labels = save_flag
         except Exception as exc:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -57,6 +57,7 @@ def test_labels2_attribute_and_method():
         base_estimator=LogisticRegression(max_iter=200),
         task="classification",
         random_state=0,
+        save_label2=True,
     )
     sh.fit(X, y)
     assert hasattr(sh, "labels2_")
@@ -68,6 +69,18 @@ def test_labels2_attribute_and_method():
     far_point = np.array([[1000, 1000, 1000, 1000]])
     far_label = sh.predict_regions(far_point)[0]
     assert far_label == -1
+
+
+def test_labels2_optional():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    sh = ModalBoundaryClustering(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        random_state=0,
+    )
+    sh.fit(X, y)
+    assert not hasattr(sh, "labels2_")
 
 
 def test_score_regression():


### PR DESCRIPTION
## Summary
- Allow `ModalBoundaryClustering` to skip computing `labels2_` via new `save_label2` flag
- Test `labels2_` persistence when enabled and absence when disabled

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a10e35b888832c8ca094af68d77d3b