### PR TITLE
Simplify label handling with region prediction option

### DIFF
--- a/src/sheshe/modal_scout_ensemble.py
+++ b/src/sheshe/modal_scout_ensemble.py
@@ -178,7 +178,7 @@ class ModalScoutEnsemble(BaseEstimator):
     # Passthrough a MBC
     mbc_kwargs: Optional[Dict[str, Any]] = None,
     verbose: int = 0,
-    save_label2: bool = False,
+    prediction_within_region: bool = False,
   ):
     self.base_estimator = base_estimator
     self.task = task
@@ -210,7 +210,7 @@ class ModalScoutEnsemble(BaseEstimator):
     self.scout_kwargs = scout_kwargs or {}
     self.mbc_kwargs = mbc_kwargs or {}
     self.verbose = verbose
-    self.save_label2 = save_label2
+    self.prediction_within_region = prediction_within_region
 
     # Atributos post-fit
     self.selected_: List[Dict[str, Any]] = []
@@ -431,8 +431,10 @@ class ModalScoutEnsemble(BaseEstimator):
           self.regions_.append(reg)
           cid += 1
 
-    if self.save_label2:
-      self.labels2_, self.label2id_ = self.predict_regions(X)
+    if self.prediction_within_region:
+      self.labels_, self.label2id_ = self.predict_regions(X)
+    else:
+      self.labels_ = self.predict(X)
 
     if self.verbose:
       print(f"[ModalScoutEnsemble] Submodelos={len(self.models_)} | Pesos≈{np.round(self.weights_, 3)}")

--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -495,7 +495,7 @@ class ModalBoundaryClustering(BaseEstimator):
         max_subspaces: int = 20,
         verbose: bool = False,
         save_labels: bool = False,
-        save_label2: bool = False,
+        prediction_within_region: bool = False,
         out_dir: Optional[Union[str, Path]] = None,
         auto_rays_by_dim: bool = True,
         use_spsa: bool = False,
@@ -536,7 +536,7 @@ class ModalBoundaryClustering(BaseEstimator):
         self.max_subspaces = max_subspaces
         self.verbose = verbose
         self.save_labels = save_labels
-        self.save_label2 = save_label2
+        self.prediction_within_region = prediction_within_region
         self.out_dir = Path(out_dir) if out_dir is not None else None
         self.auto_rays_by_dim = auto_rays_by_dim
         self.use_spsa = use_spsa
@@ -909,9 +909,10 @@ class ModalBoundaryClustering(BaseEstimator):
             save_flag = self.save_labels
             self.save_labels = False
             try:
-                self.labels_ = self.predict(X)
-                if self.save_label2:
-                    self.labels2_ = self.predict_regions(X)
+                if self.prediction_within_region:
+                    self.labels_ = self.predict_regions(X)
+                else:
+                    self.labels_ = self.predict(X)
             finally:
                 self.save_labels = save_flag
         except Exception as exc:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -50,37 +50,37 @@ def test_fit_predict_sets_labels_attribute():
     assert np.array_equal(sh.labels_, labels)
 
 
-def test_labels2_attribute_and_method():
+def test_prediction_within_region_labels():
     iris = load_iris()
     X, y = iris.data, iris.target
     sh = ModalBoundaryClustering(
         base_estimator=LogisticRegression(max_iter=200),
         task="classification",
         random_state=0,
-        save_label2=True,
+        prediction_within_region=True,
     )
     sh.fit(X, y)
-    assert hasattr(sh, "labels2_")
-    assert sh.labels2_.shape[0] == X.shape[0]
-    # calling predict_regions should match labels2_
+    assert hasattr(sh, "labels_")
+    assert sh.labels_.shape[0] == X.shape[0]
     expected = sh.predict_regions(X)
-    assert np.array_equal(sh.labels2_, expected)
-    # sample far away from training data should be marked as -1
+    assert np.array_equal(sh.labels_, expected)
     far_point = np.array([[1000, 1000, 1000, 1000]])
     far_label = sh.predict_regions(far_point)[0]
     assert far_label == -1
 
 
-def test_labels2_optional():
+def test_prediction_within_region_optional():
     iris = load_iris()
     X, y = iris.data, iris.target
     sh = ModalBoundaryClustering(
         base_estimator=LogisticRegression(max_iter=200),
         task="classification",
         random_state=0,
+        prediction_within_region=False,
     )
     sh.fit(X, y)
-    assert not hasattr(sh, "labels2_")
+    assert hasattr(sh, "labels_")
+    assert np.array_equal(sh.labels_, sh.predict(X))
 
 
 def test_score_regression():

--- a/tests/test_modal_scout_ensemble.py
+++ b/tests/test_modal_scout_ensemble.py
@@ -25,7 +25,7 @@ def test_modal_scout_ensemble_basic():
     assert isinstance(report, list) and report
 
 
-def test_modal_scout_ensemble_labels2():
+def test_modal_scout_ensemble_prediction_within_region():
     data = load_iris()
     X, y = data.data, data.target
     mse = ModalScoutEnsemble(
@@ -34,14 +34,14 @@ def test_modal_scout_ensemble_labels2():
         random_state=0,
         scout_kwargs={"max_order": 2, "top_m": 4, "sample_size": None},
         cv=2,
-        save_label2=True,
+        prediction_within_region=True,
     )
     mse.fit(X, y)
-    assert hasattr(mse, "labels2_")
+    assert hasattr(mse, "labels_")
     assert hasattr(mse, "label2id_")
-    assert mse.labels2_.shape[0] == X.shape[0]
+    assert mse.labels_.shape[0] == X.shape[0]
     labels, ids = mse.predict_regions(X)
-    assert np.array_equal(labels, mse.labels2_)
+    assert np.array_equal(labels, mse.labels_)
     assert np.array_equal(ids, mse.label2id_)
     far_point = np.array([[1000, 1000, 1000, 1000]])
     far_label, far_id = mse.predict_regions(far_point)
@@ -49,7 +49,7 @@ def test_modal_scout_ensemble_labels2():
     assert far_id[0] == -1
 
 
-def test_modal_scout_ensemble_labels2_optional():
+def test_modal_scout_ensemble_prediction_within_region_optional():
     data = load_iris()
     X, y = data.data, data.target
     mse = ModalScoutEnsemble(
@@ -60,5 +60,6 @@ def test_modal_scout_ensemble_labels2_optional():
         cv=2,
     )
     mse.fit(X, y)
-    assert not hasattr(mse, "labels2_")
+    assert hasattr(mse, "labels_")
+    assert np.array_equal(mse.labels_, mse.predict(X))
     assert not hasattr(mse, "label2id_")


### PR DESCRIPTION
## Summary
- replace `labels2_` with unified `labels_` controlled by new `prediction_within_region` flag
- update `ModalBoundaryClustering` and `ModalScoutEnsemble` to use the flag
- adjust tests for new behaviour

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a117938f7c832ca363970d596f44b4