### PR TITLE
Handle small-dimension data in SubspaceScout

### DIFF
--- a/src/sheshe/subspace_scout.py
+++ b/src/sheshe/subspace_scout.py
@@ -399,6 +399,26 @@ class SubspaceScout:
         rng = np.random.default_rng(self.random_state)
 
         X = np.asarray(X); y = np.asarray(y)
+        d = X.shape[1]
+        if d <= 2:
+            if d == 2:
+                self.results_ = [{
+                    'features': (0, 1),
+                    'order': 2,
+                    'score': 1.0,
+                    'metric': self.model_method or 'mi_synergy'
+                }]
+            elif d == 1:
+                self.results_ = [{
+                    'features': (0,),
+                    'order': 1,
+                    'score': 1.0,
+                    'metric': self.model_method or 'mi_synergy'
+                }]
+            else:
+                self.results_ = []
+            return self.results_
+
         # muestreo opcional para velocidad
         if self.sample_size and X.shape[0] > self.sample_size:
             if self.task == 'classification':

--- a/tests/test_subspace_scout.py
+++ b/tests/test_subspace_scout.py
@@ -11,3 +11,29 @@ def test_subspace_scout_basic():
     results = scout.fit(X, y)
     assert isinstance(results, list)
     assert results and all('features' in r for r in results)
+
+
+def test_subspace_scout_returns_default_for_two_dims():
+    X = np.random.rand(50, 2)
+    y = np.random.randint(0, 2, size=50)
+    scout = SubspaceScout(random_state=0)
+    res = scout.fit(X, y)
+    assert res == [{
+        'features': (0, 1),
+        'order': 2,
+        'score': 1.0,
+        'metric': 'mi_synergy'
+    }]
+
+
+def test_subspace_scout_returns_default_for_one_dim():
+    X = np.random.rand(50, 1)
+    y = np.random.randint(0, 2, size=50)
+    scout = SubspaceScout(random_state=0)
+    res = scout.fit(X, y)
+    assert res == [{
+        'features': (0,),
+        'order': 1,
+        'score': 1.0,
+        'metric': 'mi_synergy'
+    }]


### PR DESCRIPTION
## Summary
- Return deterministic features when input has two or fewer dimensions
- Add regression tests for 1D and 2D inputs

## Testing
- `PYTHONPATH=src pytest tests/test_subspace_scout.py::test_subspace_scout_basic -q`
- `PYTHONPATH=src pytest tests/test_subspace_scout.py::test_subspace_scout_returns_default_for_two_dims -q`
- `PYTHONPATH=src pytest tests/test_subspace_scout.py::test_subspace_scout_returns_default_for_one_dim -q`


------
https://chatgpt.com/codex/tasks/task_e_68a158ad01ac832cb37b344b4c4cb8cc