### PR TITLE
Allow configurable percentile bins

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ clf = ModalBoundaryClustering(
     scan_steps=24,
     smooth_window=None,             # optional moving average window
     drop_fraction=0.5,              # fallback drop from peak value
-    stop_criteria="inflexion",     # or "percentile" for decile drop
+    stop_criteria="inflexion",     # or "percentile" for percentile-bin drop
+    percentile_bins=20,             # number of percentile bins when stop_criteria="percentile"
     random_state=0
 )
 
@@ -170,10 +171,11 @@ plt.show()
 4. Along each ray, **scan radially** and compute the **first inflection point**
    according to `direction` and `stop_criteria`:
     - `center_out`: from the center outward
-    - `outside_in`: from the outside toward the center
+   - `outside_in`: from the outside toward the center
    Optionally apply a moving average (`smooth_window`) and record the **slope**
    (df/dt) at that point. With `stop_criteria="percentile"` the scan stops
-   when the value falls to a lower decile of the dataset distribution. If no
+   when the value falls to a lower percentile bin of the dataset distribution
+   (20 bins by default). If no
    stop is found, use the first point where the value drops below
    `drop_fraction` of the peak.
 5. Connect the inflection points to form the **boundary** of the region with
@@ -282,7 +284,8 @@ plt.show()
 ## Benchmark
 
 The percentile-based stopping rule avoids the point of inflection and scans
-only until the value crosses into a lower decile.  The optimized loop
+only until the value crosses into a lower percentile bin (20 bins by default).
+The optimized loop
 implementation is considerably faster than the previous vectorized version. On
 the Iris dataset:
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -62,7 +62,8 @@ clf = ModalBoundaryClustering(
     scan_steps=24,
     smooth_window=None,             # ventana de suavizado opcional
     drop_fraction=0.5,              # caída requerida desde el pico
-    stop_criteria="inflexion",     # o "percentile" para usar deciles
+    stop_criteria="inflexion",     # o "percentile" para usar percentiles
+    percentile_bins=20,             # número de cortes percentiles si stop_criteria="percentile"
     random_state=0
 )
 
@@ -97,11 +98,12 @@ reg = ModalBoundaryClustering(task="regression")
 4. Sobre cada rayo, **escanea radialmente** y calcula el punto donde detenerse
    según `direction` y `stop_criteria`:
     - `center_out`: desde el centro hacia fuera
-    - `outside_in`: desde el exterior hacia el centro
+   - `outside_in`: desde el exterior hacia el centro
    Opcionalmente aplica un promedio móvil (`smooth_window`) y registra además la
    **pendiente** (df/dt) en ese punto. Con `stop_criteria="percentile"` el
-   escaneo se detiene cuando el valor cae a un decil inferior de la
-   distribución. Si no se detecta un punto de inflexión o caída de decil, se usa
+   escaneo se detiene cuando el valor cae a un percentil inferior de la
+   distribución (20 cortes por defecto). Si no se detecta un punto de inflexión
+   o caída de percentil, se usa
    el primer valor donde la función cae por debajo de `drop_fraction` del
    máximo.
 5. Conecta los puntos de inflexión para formar la **frontera** de la región de alta probabilidad/valor.
@@ -209,7 +211,8 @@ plt.show()
 ## Benchmark
 
 La regla basada en percentiles evita el punto de inflexión y se detiene cuando
-el valor cae a un decil inferior. La implementación actual en bucle es
+el valor cae a un percentil inferior (20 cortes por defecto). La implementación
+actual en bucle es
 considerablemente más rápida que la versión vectorizada anterior. En el dataset
 de Iris:
 

--- a/experiments/benchmark_stop_criteria.py
+++ b/experiments/benchmark_stop_criteria.py
@@ -15,7 +15,7 @@ from sklearn.datasets import load_iris
 from sheshe.sheshe import ModalBoundaryClustering, find_percentile_drop
 
 
-def _vectorized_find_percentile_drop(ts, vals, direction, deciles, drop_fraction=0.5):
+def _vectorized_find_percentile_drop(ts, vals, direction, percentiles, drop_fraction=0.5):
     """Vectorized version used previously (kept here for benchmarking)."""
     if direction == "outside_in":
         ts_scan = ts[::-1]
@@ -24,7 +24,7 @@ def _vectorized_find_percentile_drop(ts, vals, direction, deciles, drop_fraction
         ts_scan = ts
         vals_scan = vals
 
-    dec_idx = np.searchsorted(deciles, vals_scan, side="right") - 1
+    dec_idx = np.searchsorted(percentiles, vals_scan, side="right") - 1
     dec_drops = np.where(np.diff(dec_idx) < 0)[0]
 
     if dec_drops.size > 0:
@@ -58,21 +58,21 @@ def benchmark_functions():
     rng = np.random.default_rng(0)
     ts = np.linspace(0, 5, 500)
     vals = np.linspace(1.0, 0.0, 500) + rng.normal(scale=0.01, size=500)
-    deciles = np.linspace(0.0, 1.0, 11)
+    percentiles = np.linspace(0.0, 1.0, 21)
     reps = 2000
 
     t0 = time.time()
     for _ in range(reps):
-        _vectorized_find_percentile_drop(ts, vals, "center_out", deciles)
+        _vectorized_find_percentile_drop(ts, vals, "center_out", percentiles)
     t_vec = time.time() - t0
 
     t0 = time.time()
     for _ in range(reps):
-        find_percentile_drop(ts, vals, "center_out", deciles)
+        find_percentile_drop(ts, vals, "center_out", percentiles)
     t_loop = time.time() - t0
 
-    res_old = _vectorized_find_percentile_drop(ts, vals, "center_out", deciles)
-    res_new = find_percentile_drop(ts, vals, "center_out", deciles)
+    res_old = _vectorized_find_percentile_drop(ts, vals, "center_out", percentiles)
+    res_new = find_percentile_drop(ts, vals, "center_out", percentiles)
     assert np.allclose(res_old, res_new)
 
     print(f"vectorized implementation: {t_vec:.4f}s")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -276,11 +276,11 @@ def test_percentile_stop_criteria():
     lo = np.array([0.0])
     hi = np.array([10.0])
 
-    deciles = np.array([0, 0.1, 0.2, 0.3, 0.4, 0.9, 0.92, 0.93, 0.94, 0.94, 1.0])
+    percentiles = np.array([0, 0.1, 0.2, 0.3, 0.4, 0.9, 0.92, 0.93, 0.94, 0.94, 1.0])
 
     sh = ModalBoundaryClustering(scan_steps=3, scan_radius_factor=2.0, stop_criteria="percentile")
     sh.bounds_ = (lo, hi)
-    r, _, _ = sh._scan_radii(center, f, dirs, X_std, deciles=deciles)
+    r, _, _ = sh._scan_radii(center, f, dirs, X_std, percentiles=percentiles)
     assert np.isclose(r[0], 1.0)
 
 


### PR DESCRIPTION
## Summary
- add `percentile_bins` option for percentile stop criterion (default 20)
- generalize decile-based logic to percentile bins
- document new option and update tests/benchmarks

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a15af86b38832c858f0733776ceaca