### PR TITLE
feat: add interactive plotly engine for 3d plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Parámetros principales:
 - `class_label`: etiqueta de la clase a mostrar cuando `task='classification'`.
 - `grid_res`: resolución de la malla usada para la superficie.
 - `alpha_surface`: transparencia de la superficie.
+- `engine`: `'matplotlib'` (por defecto) para una figura estática o `'plotly'`
+  para un gráfico interactivo.
 
 Ejemplo mínimo:
 
@@ -153,8 +155,13 @@ iris = load_iris()
 X, y = iris.data, iris.target
 
 sh = ModalBoundaryClustering().fit(X, y)
+# Modo estático con Matplotlib
 sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0])
 plt.show()
+
+# Modo interactivo con Plotly
+fig = sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0], engine="plotly")
+fig.show()
 ```
 
 ---

--- a/tests/test_plot_pair_3d.py
+++ b/tests/test_plot_pair_3d.py
@@ -1,6 +1,7 @@
 import matplotlib
 matplotlib.use('Agg')
 
+import pytest
 from sklearn.datasets import load_iris
 from sheshe import ModalBoundaryClustering
 
@@ -9,3 +10,11 @@ def test_plot_pair_3d_runs():
     X, y = load_iris(return_X_y=True)
     sh = ModalBoundaryClustering(random_state=0).fit(X, y)
     sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0])
+
+
+def test_plot_pair_3d_plotly_runs():
+    pytest.importorskip("plotly")
+    X, y = load_iris(return_X_y=True)
+    sh = ModalBoundaryClustering(random_state=0).fit(X, y)
+    fig = sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0], engine="plotly")
+    assert fig is not None


### PR DESCRIPTION
## Summary
- add `engine` option to `plot_pair_3d` allowing interactive Plotly rendering
- document interactive usage in the README
- test Plotly rendering path

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a15f86f5a8832cb4021e5dca0b5579