### PR TITLE
Add plotting utilities for ModalScoutEnsemble

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,26 @@ Output:
   'weight': 0.4193}]
 ```
 
+#### `plot_pairs(X, y=None, model_idx=0, max_pairs=None)`
+
+Visualize 2D decision surfaces of a given submodel using the same plotting
+utilities as `ModalBoundaryClustering`.
+
+```python
+feats = mse.features_[0]
+mse.plot_pairs(X, y, model_idx=0, max_pairs=1)
+```
+
+#### `plot_pair_3d(X, pair, model_idx=0, class_label=None, grid_res=50, alpha_surface=0.6, engine="matplotlib")`
+
+Render probability (classification) or predicted value (regression) as a 3D
+surface for a specific submodel.
+
+```python
+feats = mse.features_[0]
+mse.plot_pair_3d(X, (feats[0], feats[1]), model_idx=0, class_label=mse.classes_[0])
+```
+
 ### Experiments and benchmark
 
 The experiments comparing against **unsupervised** algorithms are located in

--- a/README_ES.md
+++ b/README_ES.md
@@ -343,12 +343,32 @@ Salida:
   'order': 2,
   'scout_score': -0.2368,
   'weight': 0.4336},
- {'cv_score': 0.8467,
+{'cv_score': 0.8467,
   'feat_importance': 7.3800,
   'features': (2, 1),
   'order': 2,
   'scout_score': -0.1543,
   'weight': 0.4193}]
+```
+
+#### `plot_pairs(X, y=None, model_idx=0, max_pairs=None)`
+
+Visualiza las superficies 2D de un submodelo concreto reutilizando las
+funciones de graficado de `ModalBoundaryClustering`.
+
+```python
+feats = mse.features_[0]
+mse.plot_pairs(X, y, model_idx=0, max_pairs=1)
+```
+
+#### `plot_pair_3d(X, pair, model_idx=0, class_label=None, grid_res=50, alpha_surface=0.6, engine="matplotlib")`
+
+Muestra como superficie 3D la probabilidad (clasificación) o el valor predicho
+(regresión) para un submodelo específico.
+
+```python
+feats = mse.features_[0]
+mse.plot_pair_3d(X, (feats[0], feats[1]), model_idx=0, class_label=mse.classes_[0])
 ```
 
 ### Experimentos y benchmark

--- a/tests/test_modal_scout_ensemble_plots.py
+++ b/tests/test_modal_scout_ensemble_plots.py
@@ -1,0 +1,31 @@
+import matplotlib
+matplotlib.use('Agg')
+
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+
+from sheshe import ModalScoutEnsemble
+
+
+def _fit_mse():
+    X, y = load_iris(return_X_y=True)
+    mse = ModalScoutEnsemble(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        random_state=0,
+        scout_kwargs={"max_order": 2, "top_m": 4, "sample_size": None},
+        cv=2,
+    ).fit(X, y)
+    return mse, X, y
+
+
+def test_plot_pairs_runs():
+    mse, X, y = _fit_mse()
+    mse.plot_pairs(X, y, model_idx=0, max_pairs=1)
+
+
+def test_plot_pair_3d_runs():
+    mse, X, y = _fit_mse()
+    feats = mse.features_[0]
+    pair = (feats[0], feats[1])
+    mse.plot_pair_3d(X, pair, model_idx=0, class_label=mse.classes_[0])


### PR DESCRIPTION
## Summary
- add `_get_submodel` and plotting helpers `plot_pairs` and `plot_pair_3d` to `ModalScoutEnsemble`
- document ensemble plotting options in both READMEs
- cover the new plotting API with unit tests

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a161c7c1d4832c85f74b11ce095207