### PR TITLE
Add per-cluster scoring to cluster regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ sh = ModalBoundaryClustering().fit(X, y)
 print(sh.decision_function(X[:5]))
 ```
 
+### Per-cluster metrics
+
+After fitting, `ModalBoundaryClustering` stores the discovered regions in the
+`regions_` attribute. Each `ClusterRegion` includes:
+
+- `score`: effectiveness of the estimator on samples inside the region
+  (accuracy for classification, R² for regression)
+- `metrics`: optional dictionary with additional per-cluster metrics such as
+  precision, recall, F1, MSE or MAE
+
 ### RegionInterpreter – interpret cluster regions
 
 ```python

--- a/README_ES.md
+++ b/README_ES.md
@@ -86,6 +86,16 @@ reg = ModalBoundaryClustering(task="regression")
 - `save(filepath)` → guarda el modelo mediante `joblib`
 - `ModalBoundaryClustering.load(filepath)` → carga una instancia guardada
 
+### Métricas por clúster
+
+Tras el ajuste, `ModalBoundaryClustering` guarda cada región descubierta en el
+atributo `regions_`. Cada `ClusterRegion` incluye:
+
+- `score`: eficacia del estimador sobre las muestras que pertenecen al clúster.
+  Usa exactitud (accuracy) para clasificación y R² para regresión.
+- `metrics`: diccionario opcional con métricas adicionales por clúster como
+  precision, recall, F1, MSE o MAE.
+
 ---
 
 ## ¿Cómo funciona?

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -95,6 +95,33 @@ def test_score_regression():
     assert np.isfinite(score)
 
 
+def test_cluster_region_metrics_classification():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    sh = ModalBoundaryClustering(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        random_state=0,
+    )
+    sh.fit(X, y)
+    reg = sh.regions_[0]
+    assert reg.score is not None
+    assert {"precision", "recall", "f1"}.issubset(reg.metrics.keys())
+
+
+def test_cluster_region_metrics_regression():
+    X, y = make_regression(n_samples=80, n_features=5, noise=0.1, random_state=0)
+    sh = ModalBoundaryClustering(
+        base_estimator=RandomForestRegressor(n_estimators=10, random_state=0),
+        task="regression",
+        random_state=0,
+    )
+    sh.fit(X, y)
+    reg = sh.regions_[0]
+    assert reg.score is not None
+    assert {"mse", "mae"}.issubset(reg.metrics.keys())
+
+
 def test_predict_regression_returns_base_estimator_value():
     X, y = make_regression(n_samples=80, n_features=5, noise=0.1, random_state=0)
     sh = ModalBoundaryClustering(


### PR DESCRIPTION
## Summary
- track a score for each cluster region
- compute accuracy for classification regions and R² for regression regions
- allow optional extra metrics (precision, recall, F1, MSE, MAE) per cluster
- document per-cluster metrics in the English and Spanish READMEs

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a16106fdd0832c805de72244ad4f07