### PR TITLE
feat: encapsulate OpenAI region descriptions in class

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,24 @@ RegionInterpreter.pretty_print(cards[:1])
 
 Each card includes a `cluster_id` to identify the region and the class `label`.
 
+#### OpenAIRegionInterpreter – describe regions with LLMs
+
+Install the optional ``openai`` dependency (version ``>=1``) and provide an API
+key using the ``api_key`` argument or via environment variables. The interpreter
+looks for ``OPENAI_API_KEY`` or ``OPENAI_KEY`` and, when running on Google
+Colab, also checks ``google.colab.userdata``. Language and temperature defaults
+can be configured on the interpreter and overridden at call time. Pass ``layout``
+to hint a specific output format or omit it for free‑form text. Then call
+``describe_cards`` to obtain natural‑language explanations for the region cards.
+
+```python
+from sheshe import OpenAIRegionInterpreter
+
+expl = OpenAIRegionInterpreter(model="gpt-4o-mini", language="en", temperature=0.2)
+texts = expl.describe_cards(cards, layout="bullet list", temperature=0.5)
+print(texts[0])
+```
+
 #### Visualización 3D
 `plot_pair_3d` visualiza la probabilidad de una clase o el valor predicho como
 una superficie tridimensional para un par de características.

--- a/README_ES.md
+++ b/README_ES.md
@@ -96,6 +96,25 @@ atributo `regions_`. Cada `ClusterRegion` incluye:
 - `metrics`: diccionario opcional con métricas adicionales por clúster como
   precision, recall, F1, MSE o MAE.
 
+### Descripciones en lenguaje natural con OpenAI
+
+Instala la dependencia opcional ``openai`` (versión ``>=1``) y proporciona una
+clave ya sea con el argumento ``api_key`` o mediante variables de entorno. El
+intérprete busca ``OPENAI_API_KEY`` o ``OPENAI_KEY`` y, al ejecutarse en Google
+Colab, también revisa ``google.colab.userdata``. Puedes fijar idioma y
+temperatura por defecto en el intérprete y sobreescribirlos al llamar
+``describe_cards``. Además, el parámetro ``layout`` permite sugerir un formato
+específico o dejar que el modelo responda libremente.
+
+```python
+from sheshe import RegionInterpreter, OpenAIRegionInterpreter
+
+cards = RegionInterpreter(feature_names=iris.feature_names).summarize(sh.regions_)
+explicador = OpenAIRegionInterpreter(model="gpt-4o-mini", language="es", temperature=0.2)
+textos = explicador.describe_cards(cards, layout="lista con viñetas", temperature=0.5)
+print(textos[0])
+```
+
 ---
 
 ## ¿Cómo funciona?

--- a/src/sheshe/__init__.py
+++ b/src/sheshe/__init__.py
@@ -2,6 +2,7 @@ from .sheshe import ModalBoundaryClustering, ClusterRegion
 from .subspace_scout import SubspaceScout
 from .modal_scout_ensemble import ModalScoutEnsemble
 from .region_interpretability import RegionInterpreter
+from .openai_text import OpenAIRegionInterpreter
 
 __all__ = [
     "ModalBoundaryClustering",
@@ -9,5 +10,6 @@ __all__ = [
     "SubspaceScout",
     "ModalScoutEnsemble",
     "RegionInterpreter",
+    "OpenAIRegionInterpreter",
 ]
 __version__ = "0.1.1"

--- a/src/sheshe/openai_text.py
+++ b/src/sheshe/openai_text.py
@@ -1,0 +1,178 @@
+"""Utilities to convert region interpretation cards into natural language using OpenAI."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+import os
+from contextlib import suppress
+
+try:  # optional dependency
+    from openai import OpenAI  # type: ignore
+    from openai import OpenAIError  # type: ignore
+except Exception:  # pragma: no cover - handled at runtime
+    OpenAI = None  # type: ignore
+    OpenAIError = Exception  # type: ignore
+
+try:  # pragma: no cover - importlib is stdlib but handle backports
+    from importlib import metadata as importlib_metadata
+except Exception:  # pragma: no cover
+    import importlib_metadata  # type: ignore
+
+
+class OpenAIRegionInterpreter:
+    """Generate natural language descriptions for region cards with OpenAI.
+
+    Parameters
+    ----------
+    model:
+        Name of the chat completion model. Defaults to ``"gpt-4o-mini"``.
+    api_key:
+        Optional key used when constructing the OpenAI client. It is ignored
+        when ``client`` is provided.
+    language:
+        Default language for the generated text. Can be overridden per call.
+    temperature:
+        Default sampling temperature. Can be overridden per call.
+    client:
+        Pre-instantiated OpenAI client. Mainly useful for testing/mocking.
+    **completion_args:
+        Additional arguments passed directly to ``chat.completions.create``.
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-4o-mini",
+        api_key: Optional[str] = None,
+        *,
+        language: str = "es",
+        temperature: float = 0.0,
+        client: Optional[Any] = None,
+        **completion_args: Any,
+    ) -> None:
+        if client is not None:
+            self.client = client
+        else:
+            if OpenAI is None:  # pragma: no cover - runtime guard
+                raise ImportError(
+                    "openai package is required to use OpenAIRegionInterpreter"
+                )
+            _check_openai_version()
+            api_key_resolved = self._resolve_api_key(api_key)
+            if api_key_resolved is None:
+                raise ValueError(
+                    "OpenAI API key not found. Set OPENAI_API_KEY/OPENAI_KEY "
+                    "or pass api_key explicitly."
+                )
+            self.client = OpenAI(api_key=api_key_resolved)
+        self.model = model
+        self.language = language
+        self.temperature = temperature
+        self.completion_args: Dict[str, Any] = {
+            "max_tokens": 150,
+        }
+        self.completion_args.update(completion_args)
+
+    # ------------------------------------------------------------------
+    def _resolve_api_key(self, api_key: Optional[str]) -> Optional[str]:
+        """Attempt to discover an API key from common locations."""
+        if api_key:
+            return api_key
+        for var in ("OPENAI_API_KEY", "OPENAI_KEY"):
+            val = os.getenv(var)
+            if val:
+                return val
+        with suppress(Exception):  # Google Colab secret store
+            from google.colab import userdata  # type: ignore
+            val = userdata.get("OPENAI_API_KEY")
+            if val:
+                return val
+        return None
+
+    # ------------------------------------------------------------------
+    def _card_to_prompt(self, card: Dict[str, Any], language: str) -> str:
+        """Build a textual summary of a region card for prompting."""
+        parts: List[str] = [
+            f"ID={card.get('cluster_id')}",
+            f"Etiqueta={card.get('label')}",
+            f"Centro={card.get('center')}",
+        ]
+        box = "; ".join(card.get("box_rules", []))
+        if box:
+            parts.append(f"Caja: {box}")
+        pairwise_parts = []
+        for pr in card.get("pairwise_rules", []):
+            pair = pr.get("pair", ("", ""))
+            rules = ", ".join(pr.get("rules", []))
+            pairwise_parts.append(f"{pair[0]} vs {pair[1]}: {rules}")
+        if pairwise_parts:
+            parts.append("Proyecciones: " + "; ".join(pairwise_parts))
+        notes = "; ".join(card.get("notes", []))
+        if notes:
+            parts.append(f"Notas: {notes}")
+        return " | ".join(parts)
+
+    # ------------------------------------------------------------------
+    def describe_cards(
+        self,
+        cards: Iterable[Dict[str, Any]],
+        *,
+        language: Optional[str] = None,
+        temperature: Optional[float] = None,
+        layout: Optional[str] = None,
+    ) -> List[str]:
+        """Return natural language descriptions for each region card.
+
+        Parameters
+        ----------
+        language:
+            Output language. Defaults to the interpreter's ``language`` value.
+        temperature:
+            Sampling temperature. Defaults to the interpreter's ``temperature``.
+        layout:
+            Optional textual description of the desired output format. When
+            ``None`` the model responds freely.
+        """
+
+        lang = language or self.language
+        temp = self.temperature if temperature is None else temperature
+        call_args = {**self.completion_args, "temperature": temp}
+
+        texts: List[str] = []
+        for card in cards:
+            region_summary = self._card_to_prompt(card, lang)
+            system_msg = (
+                f"Eres un asistente experto en análisis de datos. "
+                f"Describe en {lang} la región de clúster con esta información."
+            )
+            user_msg = f"Información de la región: {region_summary}."
+            if layout:
+                user_msg += f"\nUsa este formato: {layout}"
+            try:
+                resp = self.client.chat.completions.create(
+                    model=self.model,
+                    messages=[
+                        {"role": "system", "content": system_msg},
+                        {"role": "user", "content": user_msg},
+                    ],
+                    **call_args,
+                )
+                texts.append(resp.choices[0].message.content.strip())
+            except OpenAIError as exc:  # pragma: no cover - depends on API
+                raise RuntimeError(f"OpenAI request failed: {exc}") from exc
+            except Exception as exc:  # pragma: no cover - defensive
+                raise RuntimeError(f"OpenAI request failed: {exc}") from exc
+        return texts
+
+__all__ = ["OpenAIRegionInterpreter"]
+
+
+def _check_openai_version() -> None:
+    """Ensure a recent ``openai`` package is installed."""
+    try:
+        version = importlib_metadata.version("openai")
+    except Exception as exc:  # pragma: no cover - missing package
+        raise ImportError("openai package is required") from exc
+    major = int(version.split(".")[0])
+    if major < 1:  # pragma: no cover - defensive guard
+        raise ImportError(
+            f"openai>=1.0 required, found {version}. Please upgrade the openai package."
+        )

--- a/tests/test_openai_text.py
+++ b/tests/test_openai_text.py
@@ -1,0 +1,75 @@
+import pytest
+
+from sheshe.openai_text import OpenAIRegionInterpreter
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        class _Completions:
+            def __init__(self) -> None:
+                self.calls = []
+
+            def create(self, **kwargs):  # noqa: D401 - simple mock
+                self.calls.append(kwargs)
+                msg = type("M", (), {"content": "texto"})()
+                choice = type("C", (), {"message": msg})()
+                return type("R", (), {"choices": [choice]})()
+
+        class _Chat:
+            def __init__(self) -> None:
+                self.completions = _Completions()
+
+        self.chat = _Chat()
+
+
+def test_describe_cards_uses_client():
+    client = DummyClient()
+    cards = [
+        {
+            "cluster_id": 0,
+            "label": "A",
+            "center": [0, 0],
+            "box_rules": ["x <= 1"],
+            "pairwise_rules": [],
+            "notes": [],
+        }
+    ]
+    expl = OpenAIRegionInterpreter(client=client, model="mock")
+    texts = expl.describe_cards(cards, language="es", layout="lista", temperature=0.3)
+    assert texts == ["texto"]
+    assert len(client.chat.completions.calls) == 1
+    call = client.chat.completions.calls[0]
+    assert call["model"] == "mock"
+    assert call["temperature"] == 0.3
+    assert "lista" in call["messages"][1]["content"]
+    assert call["messages"][0]["role"] == "system"
+
+
+class FailingClient:
+    def __init__(self) -> None:
+        class _Completions:
+            def create(self, **kwargs):
+                raise RuntimeError("boom")
+
+        class _Chat:
+            def __init__(self) -> None:
+                self.completions = _Completions()
+
+        self.chat = _Chat()
+
+
+def test_describe_cards_raises_runtime_error():
+    client = FailingClient()
+    cards = [
+        {
+            "cluster_id": 0,
+            "label": "A",
+            "center": [0, 0],
+            "box_rules": [],
+            "pairwise_rules": [],
+            "notes": [],
+        }
+    ]
+    expl = OpenAIRegionInterpreter(client=client, model="mock")
+    with pytest.raises(RuntimeError):
+        expl.describe_cards(cards)


### PR DESCRIPTION
## Summary
- add `OpenAIRegionInterpreter` class to turn RegionInterpreter cards into natural-language text via OpenAI
- document OpenAI integration and expose the class in the public API
- test the integration with a mocked OpenAI client
- allow configuring language, temperature and optional layout format for responses
- validate OpenAI package version, auto-resolve API keys from common environments, and harden error handling

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1d94aee9c832c9321d880b3fa5055