### PR TITLE
docs: document cluster lookup and ensemble region prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ reg = ModalBoundaryClustering(task="regression")
   - `Category`: class (or "NA" in regression)
   - `slope`: df/dt at the inflection point
   - `real_value` / `norm_value`
-  - `coord_0..coord_{d-1}` or feature names
+ - `coord_0..coord_{d-1}` or feature names
+- `predict_regions(X, label_path=None)` → cluster ID(s) for each sample
+- `get_cluster(cluster_id)` → retrieve a stored `ClusterRegion`
 - `plot_pairs(X, y=None, max_pairs=None)` → 2D plots for all pair combinations
 - `save(filepath)` → save the model using `joblib`
 - `ModalBoundaryClustering.load(filepath)` → load a saved instance
@@ -114,6 +116,29 @@ from sheshe import ModalBoundaryClustering
 X, y = load_iris(return_X_y=True)
 sh = ModalBoundaryClustering().fit(X, y)
 print(sh.decision_function(X[:5]))
+```
+
+#### `predict_regions(X, label_path=None)`
+
+Return cluster identifiers for each sample based solely on the discovered
+regions.
+
+```python
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+sh = ModalBoundaryClustering().fit(X, y)
+print(sh.predict_regions(X[:3]))
+```
+
+#### `get_cluster(cluster_id)`
+
+Fetch a stored :class:`ClusterRegion` by its identifier.
+
+```python
+reg = sh.get_cluster(0)
+print(reg.center)
 ```
 
 ### Per-cluster metrics
@@ -453,6 +478,15 @@ of class probabilities from all submodels in the ensemble.
 ```python
 mse.fit(X, y)
 print(mse.predict_proba(X[:5]))
+```
+
+#### `predict_regions(X)`
+
+Return the predicted label and cluster identifier for each sample.
+
+```python
+labels, cluster_ids = mse.predict_regions(X[:3])
+print(cluster_ids)
 ```
 
 #### `report()`

--- a/README_ES.md
+++ b/README_ES.md
@@ -82,9 +82,34 @@ reg = ModalBoundaryClustering(task="regression")
   - `pendiente`: df/dt en el punto de inflexión
   - `valor_real` / `valor_norm`
   - `coord_0..coord_{d-1}` o nombres de features
+- `predict_regions(X, label_path=None)` → ID(s) de clúster por muestra
+- `get_cluster(cluster_id)` → obtiene la `ClusterRegion` con ese ID
 - `plot_pairs(X, y=None, max_pairs=None)` → gráficos 2D para todas las combinaciones de pares
 - `save(filepath)` → guarda el modelo mediante `joblib`
 - `ModalBoundaryClustering.load(filepath)` → carga una instancia guardada
+
+#### `predict_regions(X, label_path=None)`
+
+Devuelve el identificador de clúster para cada muestra basándose únicamente en
+las regiones descubiertas.
+
+```python
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+sh = ModalBoundaryClustering().fit(X, y)
+print(sh.predict_regions(X[:3]))
+```
+
+#### `get_cluster(cluster_id)`
+
+Obtiene la :class:`ClusterRegion` asociada al identificador indicado.
+
+```python
+reg = sh.get_cluster(0)
+print(reg.center)
+```
 
 ### Métricas por clúster
 
@@ -337,6 +362,25 @@ mse = ModalScoutEnsemble(
 )
 mse.fit(X, y)
 print(mse.predict(X[:5]))
+```
+
+#### `predict_proba(X)`
+
+Solo disponible para tareas de clasificación, devuelve la mezcla ponderada de
+probabilidades de clase de todos los submodelos.
+
+```python
+mse.fit(X, y)
+print(mse.predict_proba(X[:5]))
+```
+
+#### `predict_regions(X)`
+
+Devuelve la etiqueta y el `cluster_id` estimados para cada muestra.
+
+```python
+labels, cluster_ids = mse.predict_regions(X[:3])
+print(cluster_ids)
 ```
 
 #### `report()`


### PR DESCRIPTION
## Summary
- explain `predict_regions` and `get_cluster` for retrieving cluster IDs and data
- show how to obtain region memberships from `ModalScoutEnsemble`
- update Spanish docs with the same examples

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a25a9dc870832cb78316a775eb1850