### PR TITLE
docs: expand interpretability guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ After fitting, `ModalBoundaryClustering` stores the discovered regions in the
 - `metrics`: optional dictionary with additional per-cluster metrics such as
   precision, recall, F1, MSE or MAE
 
+## Interpretability
+
 ### RegionInterpreter – interpret cluster regions
 
 ```python
@@ -142,15 +144,16 @@ RegionInterpreter.pretty_print(cards[:1])
 
 Each card includes a `cluster_id` to identify the region and the class `label`.
 
-#### OpenAIRegionInterpreter – describe regions with LLMs
+### OpenAIRegionInterpreter – describe regions with LLMs
 
 Install the optional ``openai`` dependency (version ``>=1``) and provide an API
 key using the ``api_key`` argument or via environment variables. The interpreter
 looks for ``OPENAI_API_KEY`` or ``OPENAI_KEY`` and, when running on Google
 Colab, also checks ``google.colab.userdata``. Language and temperature defaults
-can be configured on the interpreter and overridden at call time. Pass ``layout``
-to hint a specific output format or omit it for free‑form text. Then call
-``describe_cards`` to obtain natural‑language explanations for the region cards.
+can be configured on the interpreter and overridden at call time. The ``layout``
+parameter lets you enforce a general output template (for example, ``"bullet list"``)
+or omit it for free‑form text. Then call ``describe_cards`` to obtain natural‑
+language explanations for the region cards.
 
 ```python
 from sheshe import OpenAIRegionInterpreter
@@ -160,7 +163,7 @@ texts = expl.describe_cards(cards, layout="bullet list", temperature=0.5)
 print(texts[0])
 ```
 
-#### Visualización 3D
+## Visualización 3D
 `plot_pair_3d` visualiza la probabilidad de una clase o el valor predicho como
 una superficie tridimensional para un par de características.
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -96,6 +96,24 @@ atributo `regions_`. Cada `ClusterRegion` incluye:
 - `metrics`: diccionario opcional con métricas adicionales por clúster como
   precision, recall, F1, MSE o MAE.
 
+## Interpretabilidad
+
+### Interpretación de regiones
+
+```python
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering, RegionInterpreter
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+sh = ModalBoundaryClustering().fit(X, y)
+cards = RegionInterpreter(feature_names=iris.feature_names).summarize(sh.regions_)
+RegionInterpreter.pretty_print(cards[:1])
+```
+
+Cada tarjeta incluye un `cluster_id` para identificar la región y la clase `label`.
+
 ### Descripciones en lenguaje natural con OpenAI
 
 Instala la dependencia opcional ``openai`` (versión ``>=1``) y proporciona una
@@ -103,8 +121,8 @@ clave ya sea con el argumento ``api_key`` o mediante variables de entorno. El
 intérprete busca ``OPENAI_API_KEY`` o ``OPENAI_KEY`` y, al ejecutarse en Google
 Colab, también revisa ``google.colab.userdata``. Puedes fijar idioma y
 temperatura por defecto en el intérprete y sobreescribirlos al llamar
-``describe_cards``. Además, el parámetro ``layout`` permite sugerir un formato
-específico o dejar que el modelo responda libremente.
+``describe_cards``. El parámetro ``layout`` permite fijar un template general
+(por ejemplo, ``"lista con viñetas"``) o dejar que el modelo responda libremente.
 
 ```python
 from sheshe import RegionInterpreter, OpenAIRegionInterpreter


### PR DESCRIPTION
## Summary
- document interpretability workflow with RegionInterpreter and OpenAIRegionInterpreter
- clarify how `layout` enforces a consistent OpenAI response template
- add Spanish `Interpretabilidad` section mirroring the English README

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a25b038ee8832cbf1de5b62f643ca1