### PR TITLE
feat: log platform metadata for clustering benchmark

### DIFF
--- a/experiments/ab_test_clustering.py
+++ b/experiments/ab_test_clustering.py
@@ -408,10 +408,18 @@ def main():
 
     df_final = pd.concat(todo, ignore_index=True)
     df_final = df_final.sort_values(["dataset", "macro_f1", "nmi"], ascending=[True, False, False])
-    df_final.to_csv("ab_results_clustering.csv", index=False)
+
+    # Escribir CSV con metadatos de plataforma como encabezado comentado
+    with open("ab_results_clustering.csv", "w", encoding="utf-8") as f:
+        for k, v in PLATFORM_INFO.items():
+            f.write(f"# {k}: {v}\n")
+        df_final.to_csv(f, index=False)
+
+    # Guardar los metadatos también en un JSON acompañante
     with open("ab_results_clustering_meta.json", "w") as f:
         json.dump(PLATFORM_INFO, f, indent=2)
-    print("\n✅ Resultados guardados en: ab_results_clustering.csv")
+
+    print("\n✅ Resultados guardados en: ab_results_clustering.csv (incluye metadatos de plataforma)")
     print("📄 Metadatos de plataforma guardados en: ab_results_clustering_meta.json")
     # Top-3 por dataset (macro_f1)
     print("\n🏁 Top-3 por dataset (macro_f1):")


### PR DESCRIPTION
## Summary
- record CPU, RAM, Python and scikit-learn versions at benchmark start
- store platform metadata as commented header in `ab_results_clustering.csv` and in accompanying JSON
- print platform configuration after benchmark completion

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sheshe')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a3dc29e88c832c9d2da473485849bd