### PR TITLE
docs: expand feature overview in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ whose responses remain consistently high for a given class or target value.
 Clusters therefore follow the supervised decision surface instead of arbitrary
 distance metrics.
 
+## Features
+
+- Supervised clustering that leverages class probabilities or predicted values.
+- Works for both classification and regression tasks.
+- Explores informative subspaces via `SubspaceScout` and ensembles with `ModalScoutEnsemble`.
+- Provides human-readable rule extraction through `RegionInterpreter`.
+- Includes built-in plotting utilities for pairwise and 3D visualizations.
+
+![Feature overview](images/feature-overview.png)
+
 ---
 
 ## Installation
@@ -45,12 +55,21 @@ The library exposes five main objects:
 - `ModalScoutEnsemble`
 - `RegionInterpreter` – turn `ClusterRegion` objects into human-readable rules
 
+Image placeholders for the above objects:
+
+![ModalBoundaryClustering](images/modalboundaryclustering.png)
+![ClusterRegion](images/clusterregion.png)
+![SubspaceScout](images/subspacescout.png)
+![ModalScoutEnsemble](images/modalscoutensemble.png)
+![RegionInterpreter](images/regioninterpreter.png)
+
 ```python
 from sheshe import (
     ModalBoundaryClustering,
     SubspaceScout,
     ModalScoutEnsemble,
     ClusterRegion,
+    RegionInterpreter,
 )
 
 # classification

--- a/README_ES.md
+++ b/README_ES.md
@@ -12,6 +12,16 @@ descubre regiones cuyas respuestas se mantienen altas para una clase o valor.
 Los clusters siguen así la superficie de decisión supervisada en lugar de
 métricas de distancia arbitrarias.
 
+## Características
+
+- Clustering supervisado que aprovecha probabilidades de clase o valores predichos.
+- Funciona tanto para tareas de clasificación como de regresión.
+- Explora subespacios informativos con `SubspaceScout` y ensamblados mediante `ModalScoutEnsemble`.
+- Extrae reglas interpretables a través de `RegionInterpreter`.
+- Incluye utilidades de graficado 2D y 3D integradas.
+
+![Resumen de características](images/feature-overview.png)
+
 ---
 
 ## Instalación
@@ -37,12 +47,21 @@ PYTHONPATH=src pytest -q
 
 ## API rápida
 
-La librería expone cuatro objetos principales:
+La librería expone cinco objetos principales:
 
 - `ModalBoundaryClustering`
 - `ClusterRegion` – dataclass con la información de cada región
 - `SubspaceScout`
 - `ModalScoutEnsemble`
+- `RegionInterpreter` – convierte `ClusterRegion` en reglas interpretables
+
+Espacios para las imágenes de los objetos anteriores:
+
+![ModalBoundaryClustering](images/modalboundaryclustering.png)
+![ClusterRegion](images/clusterregion.png)
+![SubspaceScout](images/subspacescout.png)
+![ModalScoutEnsemble](images/modalscoutensemble.png)
+![RegionInterpreter](images/regioninterpreter.png)
 
 ```python
 from sheshe import (
@@ -50,6 +69,7 @@ from sheshe import (
     SubspaceScout,
     ModalScoutEnsemble,
     ClusterRegion,
+    RegionInterpreter,
 )
 
 # clasificación
@@ -74,7 +94,9 @@ reg = ModalBoundaryClustering(task="regression")
 ### Métodos
 - `fit(X, y)`
 - `predict(X)`
+- `fit_predict(X, y=None)` → método de conveniencia equivalente a llamar a `fit` y luego a `predict` sobre los mismos datos
 - `predict_proba(X)`  → clasificación: probas por clase; regresión: valor normalizado [0,1]
+- `decision_function(X)` → valores de decisión del estimador base; recurre a `predict_proba` en clasificación o a `predict` en regresión
 - `interpretability_summary(feature_names=None)` → DataFrame con:
   - `Tipo`: "centroide" | "inflexion_point"
   - `Distancia`: radio desde el centro al punto de inflexión


### PR DESCRIPTION
## Summary
- highlight key features with dedicated section and image placeholder
- include image placeholders for main API objects
- document `fit_predict` and `decision_function` in Spanish README

## Testing
- `pip install -e .[dev]` *(failed: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3def87f6c832c9532bdf5bafbcfa4