### PR TITLE
Remove binary images and use text placeholders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,0 @@
-*.png filter=lfs diff=lfs merge=lfs -text
-*.jpg filter=lfs diff=lfs merge=lfs -text
-*.jpeg filter=lfs diff=lfs merge=lfs -text
-*.gif filter=lfs diff=lfs merge=lfs -text
-*.svg filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ distance metrics.
 - Provides human-readable rule extraction through `RegionInterpreter`.
 - Includes built-in plotting utilities for pairwise and 3D visualizations.
 
-![Feature overview](images/feature-overview.png)
+*Feature overview figure omitted (binary assets are not allowed).* 
 
 ---
 
@@ -55,13 +55,7 @@ The library exposes five main objects:
 - `ModalScoutEnsemble`
 - `RegionInterpreter` – turn `ClusterRegion` objects into human-readable rules
 
-Image placeholders for the above objects:
-
-![ModalBoundaryClustering](images/modalboundaryclustering.png)
-![ClusterRegion](images/clusterregion.png)
-![SubspaceScout](images/subspacescout.png)
-![ModalScoutEnsemble](images/modalscoutensemble.png)
-![RegionInterpreter](images/regioninterpreter.png)
+Figures illustrating these objects are omitted because binary assets are not allowed in this repository.
 
 ```python
 from sheshe import (
@@ -636,7 +630,7 @@ python experiments/paper_experiments.py --runs 5
 
 ## Images
 
-Images shown in this README are stored in the [`images/`](images/) directory. The folder is currently empty and will be populated in future updates. To avoid bloating the repository with binary files, all assets in this folder are tracked with [Git LFS](https://git-lfs.com).
+Figures have been intentionally omitted because this repository does not permit storing binary assets.
 
 ---
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -20,7 +20,7 @@ métricas de distancia arbitrarias.
 - Extrae reglas interpretables a través de `RegionInterpreter`.
 - Incluye utilidades de graficado 2D y 3D integradas.
 
-![Resumen de características](images/feature-overview.png)
+*Figura de resumen de características omitida (no se permiten archivos binarios).* 
 
 ---
 
@@ -55,13 +55,7 @@ La librería expone cinco objetos principales:
 - `ModalScoutEnsemble`
 - `RegionInterpreter` – convierte `ClusterRegion` en reglas interpretables
 
-Espacios para las imágenes de los objetos anteriores:
-
-![ModalBoundaryClustering](images/modalboundaryclustering.png)
-![ClusterRegion](images/clusterregion.png)
-![SubspaceScout](images/subspacescout.png)
-![ModalScoutEnsemble](images/modalscoutensemble.png)
-![RegionInterpreter](images/regioninterpreter.png)
+Las figuras ilustrativas de estos objetos se omiten porque el repositorio no admite archivos binarios.
 
 ```python
 from sheshe import (
@@ -536,7 +530,7 @@ python experiments/paper_experiments.py
 
 ## Imágenes
 
-Las imágenes mostradas en este README se almacenan en la carpeta [`images/`](images/). Esta carpeta está vacía por el momento y se poblará en futuras actualizaciones. Para evitar problemas con archivos binarios grandes, todos estos recursos se gestionan con [Git LFS](https://git-lfs.com).
+Las figuras se han omitido deliberadamente porque este repositorio no permite almacenar archivos binarios.
 
 ---
 

--- a/images/clusterregion.png
+++ b/images/clusterregion.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d510d03e6938ceb3034eaa08f9d4270790a04c5b9f81d67ae9b9e582cbb6d05
-size 3012

--- a/images/feature-overview.png
+++ b/images/feature-overview.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6851f114fac6f45d34f8d37c43f19a9069092bca72ea2d8b563debe9a85ead9f
-size 2929

--- a/images/modalboundaryclustering.png
+++ b/images/modalboundaryclustering.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd53762148bb4e6da914b5b6498c21b8ad18e112f329f33bb9c676ca5d775f30
-size 3407

--- a/images/modalscoutensemble.png
+++ b/images/modalscoutensemble.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a68fec1a149dee5e5f636ca7f3cfe26135aa819cc6db0d90ac20b4a0c70c153
-size 3423

--- a/images/regioninterpreter.png
+++ b/images/regioninterpreter.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2967a53f6031872a736a47dcd08ca014c6ea3d1a321fa86c697273a03902073
-size 2838

--- a/images/subspacescout.png
+++ b/images/subspacescout.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c73feeca5016091d50febcf10b9b3b867b848866a2948f563a716f19dc92262
-size 2977


### PR DESCRIPTION
## Summary
- drop all PNG assets from `images/`
- replace README and README_ES illustrations with text noting figures are omitted because binary files are not allowed

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3e773bf04832c9394c5c2464ee5a8