### PR TITLE
Expose OpenAIRegionInterpreter at package root

### DIFF
--- a/src/sheshe/__init__.py
+++ b/src/sheshe/__init__.py
@@ -2,7 +2,16 @@ from .sheshe import ModalBoundaryClustering, ClusterRegion
 from .subspace_scout import SubspaceScout
 from .modal_scout_ensemble import ModalScoutEnsemble
 from .region_interpretability import RegionInterpreter
-from .openai_text import OpenAIRegionInterpreter
+
+# ``OpenAIRegionInterpreter`` relies on the optional ``openai`` dependency.  In
+# environments where that dependency (or the module itself) is missing we still
+# want the base package to be importable.  Import lazily and fall back to a
+# ``None`` placeholder so that ``from sheshe import OpenAIRegionInterpreter``
+# works even when the optional components are unavailable.
+try:  # pragma: no cover - exercised via import side effect
+    from .openai_text import OpenAIRegionInterpreter  # type: ignore
+except Exception:  # pragma: no cover - optional dependency not installed
+    OpenAIRegionInterpreter = None  # type: ignore
 
 __all__ = [
     "ModalBoundaryClustering",
@@ -12,4 +21,5 @@ __all__ = [
     "RegionInterpreter",
     "OpenAIRegionInterpreter",
 ]
-__version__ = "0.1.1"
+
+__version__ = "0.1.3"

--- a/tests/test_openai_text.py
+++ b/tests/test_openai_text.py
@@ -1,6 +1,9 @@
 import pytest
 
-from sheshe.openai_text import OpenAIRegionInterpreter
+from sheshe import OpenAIRegionInterpreter
+
+if OpenAIRegionInterpreter is None:  # pragma: no cover - optional dependency
+    pytest.skip("OpenAIRegionInterpreter not available", allow_module_level=True)
 
 
 class DummyClient:


### PR DESCRIPTION
## Summary
- lazily import `OpenAIRegionInterpreter` in `sheshe.__init__` to keep base package importable without optional deps
- expose `OpenAIRegionInterpreter` at package root and bump version to 0.1.3
- update tests to import the interpreter from the root package and skip when unavailable

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3ebe6eb1c832cbafc70e5f0e3f8f6