### PR TITLE
Validate plot engine for 3D pair plots

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -1693,6 +1693,9 @@ class ModalBoundaryClustering(BaseEstimator):
             )
             return fig
 
+        if engine != "matplotlib":
+            raise ValueError("engine must be 'matplotlib' or 'plotly'")
+
         fig = plt.figure(figsize=(6, 5))
         ax = fig.add_subplot(111, projection="3d")
         ax.plot_surface(XI, XJ, Z, cmap="viridis", alpha=alpha_surface)

--- a/tests/test_plot_pair_3d.py
+++ b/tests/test_plot_pair_3d.py
@@ -18,3 +18,10 @@ def test_plot_pair_3d_plotly_runs():
     sh = ModalBoundaryClustering(random_state=0).fit(X, y)
     fig = sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0], engine="plotly")
     assert fig is not None
+
+
+def test_plot_pair_3d_bad_engine():
+    X, y = load_iris(return_X_y=True)
+    sh = ModalBoundaryClustering(random_state=0).fit(X, y)
+    with pytest.raises(ValueError):
+        sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0], engine="unknown")


### PR DESCRIPTION
## Summary
- enforce valid `engine` values for `ModalBoundaryClustering.plot_pair_3d`
- add regression test covering unsupported engine errors

## Testing
- `PYTHONPATH=src pytest tests/test_plot_pair_3d.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3ec1c868c832ca21dbbe10287ff04