### PR TITLE
docs: add regression retraining example

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,29 @@ labels = ModalBoundaryClustering().fit_predict(X, y)
 print(labels[:5])
 ```
 
+#### Regression example with retraining
+
+```python
+from sklearn.datasets import load_diabetes
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestRegressor
+from sheshe import ModalBoundaryClustering
+
+X, y = load_diabetes(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+# initial training with the default estimator
+reg = ModalBoundaryClustering(task="regression").fit(X_train, y_train)
+print(reg.predict(X_test)[:3])
+
+# retrain using a different base estimator
+reg_retrained = ModalBoundaryClustering(
+    base_estimator=RandomForestRegressor(random_state=0),
+    task="regression",
+).fit(X_train, y_train)
+print(reg_retrained.predict(X_test)[:3])
+```
+
 #### `decision_function(X)`
 
 Returns decision values from the underlying estimator. For classification it

--- a/README_ES.md
+++ b/README_ES.md
@@ -118,6 +118,29 @@ sh = ModalBoundaryClustering().fit(X, y)
 print(sh.predict_regions(X[:3]))
 ```
 
+#### Ejemplo de regresión con reentrenamiento
+
+```python
+from sklearn.datasets import load_diabetes
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestRegressor
+from sheshe import ModalBoundaryClustering
+
+X, y = load_diabetes(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+# entrenamiento inicial con el estimador por defecto
+reg = ModalBoundaryClustering(task="regression").fit(X_train, y_train)
+print(reg.predict(X_test)[:3])
+
+# reentrenar con un estimador base diferente
+reg_reentrenado = ModalBoundaryClustering(
+    base_estimator=RandomForestRegressor(random_state=0),
+    task="regression",
+).fit(X_train, y_train)
+print(reg_reentrenado.predict(X_test)[:3])
+```
+
 #### `get_cluster(cluster_id)`
 
 Obtiene la :class:`ClusterRegion` asociada al identificador indicado.


### PR DESCRIPTION
## Summary
- document regression workflow with a retraining example
- mirror the example in Spanish README

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3ede8fad0832c946b3d7512805c52