### PR TITLE
Remove deprecated multi_class parameter

### DIFF
--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -570,7 +570,7 @@ class ModalBoundaryClustering(BaseEstimator):
     def _fit_estimator(self, X: np.ndarray, y: Optional[np.ndarray]):
         if self.base_estimator is None:
             if self.task == "classification":
-                est = LogisticRegression(multi_class="auto", max_iter=1000)
+                est = LogisticRegression(max_iter=1000)
             else:
                 est = GradientBoostingRegressor(random_state=self.random_state)
         else:


### PR DESCRIPTION
## Summary
- avoid scikit-learn deprecation by removing multi_class parameter when constructing LogisticRegression

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sheshe')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0 due to proxy/connection issue)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fad5528c832cba34b26292e4d790