### PR TITLE
Allow custom feature names in plot utilities

### DIFF
--- a/tests/test_modal_scout_ensemble_plots.py
+++ b/tests/test_modal_scout_ensemble_plots.py
@@ -1,5 +1,6 @@
 import matplotlib
 matplotlib.use('Agg')
+import matplotlib.pyplot as plt
 
 from sklearn.datasets import load_iris
 from sklearn.linear_model import LogisticRegression
@@ -29,3 +30,21 @@ def test_plot_pair_3d_runs():
     feats = mse.features_[0]
     pair = (feats[0], feats[1])
     mse.plot_pair_3d(X, pair, model_idx=0, class_label=mse.classes_[0])
+
+
+def test_mse_feature_names_propagated():
+    mse, X, y = _fit_mse()
+    feats = mse.features_[0]
+    names = [f'f{i}' for i in range(X.shape[1])]
+    mse.plot_pairs(X, y, model_idx=0, max_pairs=1, feature_names=names)
+    ax = plt.gcf().axes[0]
+    assert ax.get_xlabel() == names[feats[0]]
+    assert ax.get_ylabel() == names[feats[1]]
+    plt.close('all')
+
+    pair = (feats[0], feats[1])
+    fig = mse.plot_pair_3d(X, pair, model_idx=0, class_label=mse.classes_[0], feature_names=names)
+    ax3d = fig.axes[0]
+    assert ax3d.get_xlabel() == names[feats[0]]
+    assert ax3d.get_ylabel() == names[feats[1]]
+    plt.close('all')

--- a/tests/test_plot_pair_3d.py
+++ b/tests/test_plot_pair_3d.py
@@ -1,5 +1,6 @@
 import matplotlib
 matplotlib.use('Agg')
+import matplotlib.pyplot as plt
 
 import pytest
 from sklearn.datasets import load_iris
@@ -25,3 +26,14 @@ def test_plot_pair_3d_bad_engine():
     sh = ModalBoundaryClustering(random_state=0).fit(X, y)
     with pytest.raises(ValueError):
         sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0], engine="unknown")
+
+
+def test_plot_pair_3d_feature_names():
+    X, y = load_iris(return_X_y=True)
+    sh = ModalBoundaryClustering(random_state=0).fit(X, y)
+    names = ['a', 'b', 'c', 'd']
+    fig = sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0], feature_names=names)
+    ax = fig.axes[0]
+    assert ax.get_xlabel() == 'a'
+    assert ax.get_ylabel() == 'b'
+    plt.close('all')

--- a/tests/test_plot_pairs.py
+++ b/tests/test_plot_pairs.py
@@ -1,3 +1,6 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
 import pytest
 from sklearn.datasets import load_iris
 from sheshe import ModalBoundaryClustering
@@ -8,3 +11,14 @@ def test_plot_pairs_mismatched_y_length():
     sh = ModalBoundaryClustering(random_state=0).fit(X, y)
     with pytest.raises(AssertionError, match="misma longitud"):
         sh.plot_pairs(X, y[:-1])
+
+
+def test_plot_pairs_feature_names():
+    X, y = load_iris(return_X_y=True)
+    sh = ModalBoundaryClustering(random_state=0).fit(X, y)
+    names = ['a', 'b', 'c', 'd']
+    sh.plot_pairs(X, y, max_pairs=1, feature_names=names)
+    ax = plt.gcf().axes[0]
+    assert ax.get_xlabel() == 'a'
+    assert ax.get_ylabel() == 'b'
+    plt.close('all')


### PR DESCRIPTION
## Summary
- add optional `feature_names` parameter to `plot_pairs` and `plot_pair_3d`
- propagate feature names through `ModalScoutEnsemble` plotting helpers
- cover feature name labelling in new tests

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3fd88cc4c832cab5fb73a4ea101b1