### PR TITLE
Reduce plots generated by plot_pairs

### DIFF
--- a/src/sheshe/modal_scout_ensemble.py
+++ b/src/sheshe/modal_scout_ensemble.py
@@ -600,6 +600,8 @@ class ModalScoutEnsemble(BaseEstimator):
     model_idx: int = 0,
     max_pairs: Optional[int] = None,
     feature_names: Optional[Sequence[str]] = None,
+    block_size: Optional[int] = None,
+    max_classes: Optional[int] = None,
   ) -> None:
     """Visualiza superficies 2D para un submodelo específico.
 
@@ -620,7 +622,14 @@ class ModalScoutEnsemble(BaseEstimator):
       sub_names = [feature_names[f] for f in feats_list]
     else:
       sub_names = None
-    mbc.plot_pairs(Xs, y, max_pairs=max_pairs, feature_names=sub_names)
+    mbc.plot_pairs(
+      Xs,
+      y,
+      max_pairs=max_pairs,
+      feature_names=sub_names,
+      block_size=block_size,
+      max_classes=max_classes,
+    )
 
   def plot_pair_3d(
     self,

--- a/tests/test_plot_pairs.py
+++ b/tests/test_plot_pairs.py
@@ -3,6 +3,7 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import pytest
 from sklearn.datasets import load_iris
+from sklearn.datasets import make_regression
 from sheshe import ModalBoundaryClustering
 
 
@@ -22,3 +23,20 @@ def test_plot_pairs_feature_names():
     assert ax.get_xlabel() == 'a'
     assert ax.get_ylabel() == 'b'
     plt.close('all')
+
+
+def test_plot_pairs_max_classes():
+    X, y = load_iris(return_X_y=True)
+    sh = ModalBoundaryClustering(random_state=0).fit(X, y)
+    sh.plot_pairs(X, y, max_pairs=1, max_classes=1)
+    assert len(plt.get_fignums()) == 1
+    plt.close('all')
+
+
+def test_plot_pairs_regression_deciles():
+    X, y = make_regression(n_samples=40, n_features=3, random_state=0)
+    sh = ModalBoundaryClustering(task="regression", random_state=0).fit(X, y)
+    sh.plot_pairs(X, y, max_pairs=1, max_classes=5)
+    assert len(plt.get_fignums()) == 1
+    plt.close('all')
+


### PR DESCRIPTION
## Summary
- Overlay regression pair plots with decile-based contours and limit shown bins via `max_classes`
- Add `max_classes` to `plot_pairs` and propagate through `ModalScoutEnsemble`
- Test `plot_pairs` with class limit and regression deciles

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4013ebbb8832c9f9ba7a9a6ac05b6