### PR TITLE
Fix README figure-saving example

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,9 +409,9 @@ import matplotlib.pyplot as plt
 out_dir = Path("images")
 out_dir.mkdir(exist_ok=True)
 for i, fig_num in enumerate(plt.get_fignums()):
-    plt.figure(fig_num)
-    plt.savefig(out_dir / f"pair_{i}.png")
-plt.close(fig_num)
+    fig = plt.figure(fig_num)
+    fig.savefig(out_dir / f"pair_{i}.png")
+    plt.close(fig)
 ```
 
 ### Plotting with pandas DataFrames


### PR DESCRIPTION
## Summary
- fix NameError in README's figure-saving snippet by closing figures inside the loop

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3fea38cec832c9ec65f74f2744809