### PR TITLE
Add adaptive ray casting with direction fallback

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -230,10 +230,9 @@ def test_membership_matrix_no_directions():
     sh.fit(X, y)
     M = sh._membership_matrix(X)
     assert M.shape == (X.shape[0], len(sh.regions_))
-    assert np.all(M == 0)
-    base_pred = sh.pipeline_.predict(X)
+    assert np.any(M != 0)
     pred = sh.predict(X)
-    assert np.all(pred == base_pred)
+    assert pred.shape == (X.shape[0],)
 
 
 def test_base_2d_rays_zero_raises_in_3d():

--- a/tests/test_ray_utils_verbose.py
+++ b/tests/test_ray_utils_verbose.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+from sheshe.sheshe import (
+    enforce_minimum_subspace,
+    per_direction_step_lengths,
+    cast_rays_with_censoring,
+)
+
+
+def test_enforce_minimum_subspace_fallback_verbose():
+    X = np.random.randn(10, 3)
+    dirs = enforce_minimum_subspace(None, X, k_fallback=2, verbose=1, log_fn=lambda m: None)
+    assert dirs.shape == (4, 3)
+    norms = np.linalg.norm(dirs, axis=1)
+    assert np.allclose(norms, 1.0)
+    axes = np.argmax(np.abs(dirs), axis=1)
+    counts = np.bincount(axes, minlength=3)
+    nz = counts[counts > 0]
+    assert np.all(nz == 2)
+
+
+def test_cast_rays_with_censoring_verbose():
+    center = np.zeros(2)
+    dirs = np.array([[1.0, 0.0]])
+    std = np.ones(2)
+    steps = per_direction_step_lengths(dirs, std)
+
+    def f(x):
+        return float(np.exp(-np.linalg.norm(x)))
+
+    radii, pts, slopes, metrics = cast_rays_with_censoring(
+        center=center,
+        directions=dirs,
+        eval_fn=f,
+        bounds=None,
+        max_steps=3,
+        step_lengths=steps,
+        min_drop=10.0,
+        min_slope=0.0,
+        verbose=1,
+        log_fn=lambda m: None,
+    )
+
+    assert metrics["censored_mask"][0]
+    assert np.isclose(radii[0], steps[0] * 3)
+    assert np.allclose(pts[0], np.array([steps[0] * 3, 0.0]))


### PR DESCRIPTION
## Summary
- ensure ray directions never empty by enforcing fallback to high-variance axes
- add scale-aware step computation and censored ray casting utilities with optional verbose logging
- integrate adaptive scanning with metrics tracking and expand tests for fallback and censoring

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae88ac8c9c832c822af6ec8e89fdd8