### PR TITLE
Skip empty regions and raise base_2d_rays default

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,8 +662,8 @@ python experiments/paper_experiments.py --runs 5
 ---
 
 ## Key parameters
-- `base_2d_rays` → controls angular resolution in 2D (24 by default). 3D scales
-  to ~26; d>3 uses subspaces.
+- `base_2d_rays` → controls angular resolution in 2D (32 by default). 3D scales
+  to ~34; d>3 uses subspaces.
 - `direction` → "center_out" | "outside_in" to locate the inflection point.
 - `scan_radius_factor`, `scan_steps` → size and resolution of the radial scan.
 - `grad_*` → hyperparameters of gradient ascent (rate, iterations, tolerances).
@@ -676,7 +676,7 @@ python experiments/paper_experiments.py --runs 5
 ---
 
 ## Performance tips
-- Defaults favour speed: `base_2d_rays=24`, `scan_steps=24` and `n_max_seeds=2`.
+- Defaults favour speed: `base_2d_rays=32`, `scan_steps=24` and `n_max_seeds=2`.
 - The heuristic `auto_rays_by_dim=True` (default) reduces rays for high dimensional datasets:
   - 25–64 features → `base_2d_rays` capped at 16.
   - 65+ features → `base_2d_rays` capped at 12.

--- a/README_ES.md
+++ b/README_ES.md
@@ -546,7 +546,7 @@ python experiments/paper_experiments.py
 ---
 
 ## Parámetros clave
-- `base_2d_rays` → controla la resolución angular en 2D (24 por defecto). 3D escala ~26; d>3 usa subespacios.
+- `base_2d_rays` → controla la resolución angular en 2D (32 por defecto). 3D escala ~34; d>3 usa subespacios.
 - `direction` → "center_out" | "outside_in" para localizar el punto de inflexión.
 - `scan_radius_factor`, `scan_steps` → tamaño y resolución del escaneo radial.
 - `grad_*` → hiperparámetros del ascenso (tasa, iteraciones, tolerancias).

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,7 @@
 # tests/test_basic.py
 import numpy as np
 import pytest
+import warnings
 from sklearn.datasets import load_iris, make_regression, make_classification
 from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
@@ -228,7 +229,11 @@ def test_membership_matrix_no_directions():
         ray_mode="grid",
     )
     sh.fit(X, y)
-    M = sh._membership_matrix(X)
+    assert all(reg.directions.size > 0 for reg in sh.regions_)
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("error")
+        M = sh._membership_matrix(X)
+    assert len(record) == 0
     assert M.shape == (X.shape[0], len(sh.regions_))
     assert np.any(M != 0)
     pred = sh.predict(X)


### PR DESCRIPTION
## Summary
- Skip appending modal regions when no directions are found and purge any empty region
- Raise default `base_2d_rays` to 32 and update docs
- Test that membership matrix handles empty-direction cases without warnings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aea2025a14832c9a68bf979c05d72f