### PR TITLE
Add trust-region Newton optimizer

### DIFF
--- a/benchmark/newton_vs_gradient_ab_test.csv
+++ b/benchmark/newton_vs_gradient_ab_test.csv
@@ -1,2 +1,2 @@
 time_grad_mean,time_newton_mean,speedup,f_evals_grad_mean,f_evals_newton_mean,grad_evals_grad_mean,grad_evals_newton_mean,hess_evals_newton_mean
-0.0013245249999954468,8.989759999735724e-05,14.733708130521665,48.0,2.4,43.8,2.4,1.4
+0.0034222367999973357,0.00030681399998684357,11.154109004621967,48.0,0.0,43.8,2.4,1.4


### PR DESCRIPTION
## Summary
- implement finite difference Hessian utility
- add Newton trust-region optimizer with optional analytic derivatives and fallback to gradient ascent when Hessian is not negative definite
- benchmark Newton vs gradient ascent and record results

## Testing
- `PYTHONPATH=src pytest -q`
- `python benchmark/newton_vs_gradient_ab_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68aff5873828832cb9ca1b74be49fd26