### PR TITLE
Use stdout for logging to support notebook environments

### DIFF
--- a/src/sheshe/modal_scout_ensemble.py
+++ b/src/sheshe/modal_scout_ensemble.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import List, Tuple, Dict, Any, Optional, Sequence, Callable
 import logging
+import sys
 import math, time
 import numpy as np
 
@@ -213,7 +214,9 @@ class ModalScoutEnsemble(BaseEstimator):
     self.verbose = verbose
     self.logger = logging.getLogger(self.__class__.__name__)
     if not self.logger.handlers:
-      self.logger.addHandler(logging.StreamHandler())
+      # Redirigimos a ``stdout`` para compatibilidad con entornos como Colab
+      # donde ``stderr`` puede mostrarse por separado o no capturarse.
+      self.logger.addHandler(logging.StreamHandler(stream=sys.stdout))
     if verbose >= 2:
       self.logger.setLevel(logging.DEBUG)
     elif verbose == 1:

--- a/src/sheshe/region_interpretability.py
+++ b/src/sheshe/region_interpretability.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 from typing import Any, Dict, List, Sequence, Tuple, Optional
 import logging
+import sys
 from contextlib import contextmanager
 import numpy as np
 
@@ -18,7 +19,10 @@ except Exception:
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:
-    logger.addHandler(logging.StreamHandler())
+    # En ambientes como notebooks o Google Colab el ``stderr`` no siempre se
+    # muestra de forma evidente.  Redirigimos los logs a ``stdout`` para que
+    # el usuario pueda verlos independientemente del entorno de ejecución.
+    logger.addHandler(logging.StreamHandler(stream=sys.stdout))
 
 
 @contextmanager

--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -5,6 +5,7 @@ import itertools
 import math
 import time
 import logging
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union, Callable, Sequence
@@ -941,7 +942,10 @@ class ModalBoundaryClustering(BaseEstimator):
         self.verbose = verbose
         self.logger = logging.getLogger(self.__class__.__name__)
         if not self.logger.handlers:
-            self.logger.addHandler(logging.StreamHandler())
+            # En algunos entornos (ej. notebooks o Google Colab) ``stderr`` se
+            # presenta de forma distinta al flujo estándar.  Usamos ``stdout``
+            # para asegurar que los mensajes se muestren siempre.
+            self.logger.addHandler(logging.StreamHandler(stream=sys.stdout))
         if verbose >= 2:
             self.logger.setLevel(logging.DEBUG)
         elif verbose == 1:


### PR DESCRIPTION
## Summary
- Redirect all built-in loggers to use `stdout` instead of `stderr`
- Document why this helps show logs in Colab and other notebook environments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b13c9e3040832c863cd01ba804661c