### PR TITLE
Polish README introductions in English and Spanish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,21 @@
 # SheShe
 **Smart High-dimensional Edge Segmentation & Hyperboundary Explorer**
 
-Edge segmentation and hyperboundary exploration based on **local maxima** of
-the **class probability** (classification) or the **predicted value**
-(regression). It is a supervised clustering algorithm.
+**SheShe** transforms any probabilistic model into a guided explorer of its own
+decision landscape. By following the **local maxima** of the **class
+probability** (classification) or the **predicted value** (regression), it
+discovers crisp, human‑readable regions that obey the supervised boundary of the
+problem. Rather than grouping samples by raw feature distance, SheShe learns
+from labeled data and carves clusters directly on top of the model’s decision
+surface.
 
-Unlike traditional unsupervised clustering methods that rely only on feature
-similarity, SheShe learns from labeled examples. A base estimator models the
-relationship between inputs and targets, and the algorithm discovers regions
-whose responses remain consistently high for a given class or target value.
-Clusters therefore follow the supervised decision surface instead of arbitrary
-distance metrics.
+## Highlights
 
-## Features
-
-- Supervised clustering that leverages class probabilities or predicted values.
-- Works for both classification and regression tasks.
-- Explores informative subspaces via `SubspaceScout` and ensembles with `ModalScoutEnsemble`.
-- Provides human-readable rule extraction through `RegionInterpreter`.
-- Includes built-in plotting utilities for pairwise and 3D visualizations.
+- Supervised clustering driven by the model’s own probabilities or predictions.
+- Unified support for classification and regression tasks.
+- Subspace exploration with `SubspaceScout` and ensembles via `ModalScoutEnsemble`.
+- Human-readable rule extraction through `RegionInterpreter`.
+- Built-in plotting utilities for pairwise and 3D visualisations.
 
 *Feature overview figure omitted (binary assets are not allowed).* 
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,24 +1,20 @@
 # SheShe  
 **Smart High-dimensional Edge Segmentation & Hyperboundary Explorer**
 
-Segmentación de bordes y exploración de hiper-fronteras basada en **máximos locales** de
-la **probabilidad por clase** (clasificación) o del **valor predicho** (regresión).
-Se trata de un algoritmo de clustering supervisado.
+**SheShe** convierte cualquier modelo probabilístico en un explorador guiado de
+su paisaje de decisión. Siguiendo los **máximos locales** de la **probabilidad
+por clase** (clasificación) o del **valor predicho** (regresión), delimita
+regiones nítidas e interpretables que se apoyan en la frontera supervisada del
+problema. En lugar de agrupar por distancia, aprende de ejemplos etiquetados y
+traza los clúesteres directamente sobre la superficie de decisión.
 
-A diferencia de los métodos de clustering no supervisados que dependen solo de
-la similitud entre características, SheShe aprovecha ejemplos etiquetados. Un
-estimador base modela la relación entre entradas y objetivos, y el algoritmo
-descubre regiones cuyas respuestas se mantienen altas para una clase o valor.
-Los clusters siguen así la superficie de decisión supervisada en lugar de
-métricas de distancia arbitrarias.
+## Destacados
 
-## Características
-
-- Clustering supervisado que aprovecha probabilidades de clase o valores predichos.
-- Funciona tanto para tareas de clasificación como de regresión.
-- Explora subespacios informativos con `SubspaceScout` y ensamblados mediante `ModalScoutEnsemble`.
-- Extrae reglas interpretables a través de `RegionInterpreter`.
-- Incluye utilidades de graficado 2D y 3D integradas.
+- Clustering supervisado impulsado por las propias probabilidades o predicciones del modelo.
+- Soporte unificado para tareas de clasificación y regresión.
+- Exploración de subespacios con `SubspaceScout` y ensamblados mediante `ModalScoutEnsemble`.
+- Extracción de reglas interpretables a través de `RegionInterpreter`.
+- Utilidades de graficado integradas para visualizaciones 2D y 3D.
 
 *Figura de resumen de características omitida (no se permiten archivos binarios).* 
 


### PR DESCRIPTION
## Summary
- Revise opening section of README to emphasize SheShe's decision-boundary exploration
- Rename feature list to Highlights and sharpen bullet wording
- Mirror the improved tone in the Spanish README

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b146a0d06c832cbd0ed1311ee05453