### PR TITLE
Add A/B testing example comparing density penalty

### DIFF
--- a/examples/ab_density_comparison.py
+++ b/examples/ab_density_comparison.py
@@ -1,0 +1,55 @@
+import numpy as np
+from sklearn.datasets import make_blobs
+from sklearn.neighbors import NearestNeighbors
+
+from sheshe import ModalBoundaryClustering
+
+
+# -- Dataset ---------------------------------------------------------------
+# A simple 2D synthetic dataset with 3 well separated clusters.
+X, y = make_blobs(n_samples=600, centers=3, cluster_std=1.0, random_state=0)
+
+# Pre-compute dataset bounds for out-of-range checks
+lo, hi = X.min(axis=0), X.max(axis=0)
+
+
+def fit_model(alpha: float):
+    """Train SheShe with a given density_alpha and return cluster centers."""
+    model = ModalBoundaryClustering(
+        density_alpha=alpha,
+        density_k=15,
+        random_state=0,
+    )
+    model.fit(X, y)
+    centers = np.vstack([reg.center for reg in model.regions_])
+    return centers
+
+
+def centers_density(centers: np.ndarray) -> np.ndarray:
+    """Estimate local density via 5-NN distances (inverse mean distance)."""
+    nn = NearestNeighbors(n_neighbors=5)
+    nn.fit(X)
+    dists, _ = nn.kneighbors(centers)
+    return 1.0 / (dists.mean(axis=1) + 1e-12)
+
+
+def out_of_bounds(centers: np.ndarray) -> np.ndarray:
+    """Boolean mask of centers that fall outside the original data bounds."""
+    return np.any((centers < lo) | (centers > hi), axis=1)
+
+
+# -- A/B configurations ----------------------------------------------------
+centers_a = fit_model(alpha=0.0)  # A: no density penalty
+centers_b = fit_model(alpha=1.0)  # B: density-aware
+
+# Compute diagnostics
+rho_a = centers_density(centers_a)
+rho_b = centers_density(centers_b)
+
+print("Baseline (density_alpha=0):")
+print(f"  mean density: {rho_a.mean():.3f}")
+print(f"  out-of-bounds centers: {out_of_bounds(centers_a).sum()}")
+
+print("\nDensity-aware (density_alpha=1):")
+print(f"  mean density: {rho_b.mean():.3f}")
+print(f"  out-of-bounds centers: {out_of_bounds(centers_b).sum()}")

--- a/examples/density_timing_benchmark.py
+++ b/examples/density_timing_benchmark.py
@@ -1,0 +1,36 @@
+import time
+from typing import List, Tuple
+
+import numpy as np
+from sklearn.datasets import make_blobs
+
+from sheshe import ModalBoundaryClustering
+
+
+def time_fit(n: int) -> Tuple[float, float]:
+    """Return fitting times without and with density for dataset of size n."""
+    X, y = make_blobs(n_samples=n, centers=5, random_state=0)
+
+    model_a = ModalBoundaryClustering(density_alpha=0, random_state=0)
+    start = time.perf_counter()
+    model_a.fit(X, y)
+    t_a = time.perf_counter() - start
+
+    model_b = ModalBoundaryClustering(density_alpha=1, random_state=0)
+    start = time.perf_counter()
+    model_b.fit(X, y)
+    t_b = time.perf_counter() - start
+
+    return t_a, t_b
+
+
+def main() -> None:
+    sizes: List[int] = [100 * 2 ** k for k in range(10)]
+    print("n_samples, time_no_density(s), time_with_density(s), delta(s)")
+    for n in sizes:
+        t0, t1 = time_fit(n)
+        print(f"{n:8d}, {t0:.4f}, {t1:.4f}, {t1 - t0:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bounds_margin.py
+++ b/tests/test_bounds_margin.py
@@ -1,0 +1,13 @@
+import numpy as np
+from sheshe import ModalBoundaryClustering
+
+def test_bounds_margin_optional():
+    X = np.array([[0.0, 0.0], [1.0, 1.0]])
+    sh = ModalBoundaryClustering(bounds_margin=0.0)
+    lo, hi = sh._bounds_from_data(X)
+    assert np.allclose(lo, [0.0, 0.0])
+    assert np.allclose(hi, [1.0, 1.0])
+    sh2 = ModalBoundaryClustering(bounds_margin=0.1)
+    lo2, hi2 = sh2._bounds_from_data(X)
+    assert np.all(lo2 < 0.0)
+    assert np.all(hi2 > 1.0)

--- a/tests/test_density_fallback.py
+++ b/tests/test_density_fallback.py
@@ -1,0 +1,25 @@
+import numpy as np
+from sheshe import ModalBoundaryClustering
+from sklearn.linear_model import LogisticRegression
+from sklearn.neighbors import KDTree
+import sheshe.sheshe as sheshe_mod
+
+
+def test_density_fallback(monkeypatch):
+    # Force fallback path without hnswlib
+    monkeypatch.setattr(sheshe_mod, "hnswlib", None)
+    X = np.random.RandomState(0).randn(30, 2)
+    y = (X[:, 0] + X[:, 1] > 0).astype(int)
+    sh = ModalBoundaryClustering(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        density_alpha=0.5,
+        density_k=3,
+        random_state=0,
+    )
+    sh.fit(X, y)
+    # Ensure KDTree is used as a lightweight fallback
+    assert isinstance(sh._nn_density, KDTree)
+    dens = sh._density(X[:1])
+    assert dens.shape == (1,)
+    assert np.isfinite(dens).all()


### PR DESCRIPTION
## Summary
- add `examples/ab_density_comparison.py` to illustrate A/B testing between vanilla and density-aware SheShe models
- script reports mean kNN density and checks for cluster centers that fall outside data bounds
- include `examples/density_timing_benchmark.py` to benchmark overhead of density-aware clustering across dataset sizes
- introduce optional `bounds_margin` parameter to disable automatic bounds expansion
- cover density fallback and bounds-margin behavior with dedicated unit tests

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python examples/density_timing_benchmark.py`


------
https://chatgpt.com/codex/tasks/task_e_68b230aa1c4c832c884a2a5041d024e0