### PR TITLE
Ensure pretty_print logs display

### DIFF
--- a/src/sheshe/region_interpretability.py
+++ b/src/sheshe/region_interpretability.py
@@ -18,6 +18,7 @@ except Exception:
     _HAS_PANDAS = False
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 if not logger.handlers:
     # En ambientes como notebooks o Google Colab el ``stderr`` no siempre se
     # muestra de forma evidente.  Redirigimos los logs a ``stdout`` para que


### PR DESCRIPTION
## Summary
- Make `pretty_print` log at INFO level so outputs show up in environments like Google Colab

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2802a5b78832c862d9d13fcac8250