### PR TITLE
feat: add optional shushu ensemble method

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ subspaces = scout.fit(X, y)
 
 ## ModalScoutEnsemble
 
-`ModalScoutEnsemble` trains multiple ModalBoundaryClustering models on the top subspaces returned by `SubspaceScout` and combines their predictions.
+`ModalScoutEnsemble` trains multiple ModalBoundaryClustering models on the top subspaces returned by `SubspaceScout` and combines their predictions. Set `ensemble_method="shushu"` to delegate the ensemble to the `ShuShu` optimizer.
 
 ```python
 from sheshe import ModalScoutEnsemble
@@ -556,6 +556,7 @@ mse = ModalScoutEnsemble(
     random_state=0,
     scout_kwargs={"max_order": 2, "top_m": 4, "sample_size": None},
     cv=2,
+    # ensemble_method="shushu" would use the ShuShu optimizer
 )
 mse.fit(X, y)
 print(mse.predict(X[:5]))

--- a/README_ES.md
+++ b/README_ES.md
@@ -422,7 +422,7 @@ subspaces = scout.fit(X, y)
 
 ## ModalScoutEnsemble
 
-`ModalScoutEnsemble` entrena varios modelos `ModalBoundaryClustering` en los mejores subespacios devueltos por `SubspaceScout` y combina sus predicciones.
+`ModalScoutEnsemble` entrena varios modelos `ModalBoundaryClustering` en los mejores subespacios devueltos por `SubspaceScout` y combina sus predicciones. Establece `ensemble_method="shushu"` para delegar el ensamble en el optimizador `ShuShu`.
 
 ```python
 from sheshe import ModalScoutEnsemble
@@ -438,6 +438,7 @@ mse = ModalScoutEnsemble(
     random_state=0,
     scout_kwargs={"max_order": 2, "top_m": 4, "sample_size": None},
     cv=2,
+    # ensemble_method="shushu" utilizaría el optimizador ShuShu
 )
 mse.fit(X, y)
 print(mse.predict(X[:5]))

--- a/tests/test_modal_scout_ensemble.py
+++ b/tests/test_modal_scout_ensemble.py
@@ -63,3 +63,28 @@ def test_modal_scout_ensemble_prediction_within_region_optional():
     assert hasattr(mse, "labels_")
     assert np.array_equal(mse.labels_, mse.predict(X))
     assert not hasattr(mse, "label2id_")
+
+
+def test_modal_scout_ensemble_with_shushu():
+    data = load_iris()
+    X, y = data.data, data.target
+    mse = ModalScoutEnsemble(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        random_state=0,
+        ensemble_method="shushu",
+        shushu_kwargs={
+            "k": 5,
+            "rf_estimators": 5,
+            "importance_sample_size": 60,
+            "max_iter": 5,
+        },
+    )
+    mse.fit(X, y)
+    yhat = mse.predict(X)
+    assert yhat.shape == y.shape
+    proba = mse.predict_proba(X[:5])
+    assert proba.shape[0] == 5
+    labels, ids = mse.predict_regions(X[:5])
+    assert labels.shape == (5,)
+    assert ids.shape == (5,)


### PR DESCRIPTION
## Summary
- allow selecting the ensemble method in `ModalScoutEnsemble`
- support `ShuShu` optimizer via `ensemble_method="shushu"`
- document and test the new `ShuShu` option

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b35fb733e0832ca1ea507f56369029