### PR TITLE
Add fit_predict to ModalScoutEnsemble

### DIFF
--- a/src/sheshe/modal_scout_ensemble.py
+++ b/src/sheshe/modal_scout_ensemble.py
@@ -480,6 +480,26 @@ class ModalScoutEnsemble(BaseEstimator):
     self.logger.info("Submodelos=%d | Pesos≈%s", len(self.models_), np.round(self.weights_, 3))
     return self
 
+  def fit_predict(self, X: np.ndarray, y: np.ndarray) -> np.ndarray:
+    """Ajusta el ensamble y devuelve las predicciones para ``X``.
+
+    Equivalente a ejecutar ``fit(X, y)`` seguido de ``predict(X)``.
+
+    Parameters
+    ----------
+    X : ndarray of shape (n_samples, n_features)
+        Datos de entrenamiento.
+    y : ndarray of shape (n_samples,)
+        Valores objetivo.
+
+    Returns
+    -------
+    ndarray
+        Predicciones del modelo para cada muestra de ``X``.
+    """
+    self.fit(X, y)
+    return self.predict(X)
+
   def predict_proba(self, X: np.ndarray) -> np.ndarray:
     if self.ensemble_method.lower() == "shushu":
       if self.fitted_task_ != "classification":

--- a/tests/test_modal_scout_ensemble.py
+++ b/tests/test_modal_scout_ensemble.py
@@ -15,8 +15,7 @@ def test_modal_scout_ensemble_basic():
         scout_kwargs={"max_order": 2, "top_m": 4, "sample_size": None},
         cv=2,
     )
-    mse.fit(X, y)
-    yhat = mse.predict(X)
+    yhat = mse.fit_predict(X, y)
     assert yhat.shape == y.shape
     proba = mse.predict_proba(X[:5])
     assert proba.shape[0] == 5
@@ -59,9 +58,10 @@ def test_modal_scout_ensemble_prediction_within_region_optional():
         scout_kwargs={"max_order": 2, "top_m": 4, "sample_size": None},
         cv=2,
     )
-    mse.fit(X, y)
+    yhat = mse.fit_predict(X, y)
     assert hasattr(mse, "labels_")
-    assert np.array_equal(mse.labels_, mse.predict(X))
+    assert np.array_equal(yhat, mse.labels_)
+    assert np.array_equal(yhat, mse.predict(X))
     assert not hasattr(mse, "label2id_")
 
 
@@ -80,8 +80,7 @@ def test_modal_scout_ensemble_with_shushu():
             "max_iter": 5,
         },
     )
-    mse.fit(X, y)
-    yhat = mse.predict(X)
+    yhat = mse.fit_predict(X, y)
     assert yhat.shape == y.shape
     proba = mse.predict_proba(X[:5])
     assert proba.shape[0] == 5


### PR DESCRIPTION
## Summary
- add `fit_predict` helper to ModalScoutEnsemble for one-step training and inference
- document usage in new method docstring
- update tests to exercise `fit_predict`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3c50ebd90832cbd9d7ead34040cad