### PR TITLE
Handle non-integer region ids in region extractor

### DIFF
--- a/src/sheshe/region_interpretability.py
+++ b/src/sheshe/region_interpretability.py
@@ -159,14 +159,18 @@ def _rule_text(a: float, b: float, c: float, xname: str, yname: str, decimals: i
 
 # ==================== Núcleo de interpretabilidad ====================
 
-def _extract_region(reg: Any) -> Tuple[int, Any, np.ndarray, np.ndarray, np.ndarray]:
+def _extract_region(reg: Any) -> Tuple[Any, Any, np.ndarray, np.ndarray, np.ndarray]:
     """Admite dict u objeto (p.ej., ClusterRegion).
 
     Devuelve ``cluster_id``, ``label``, ``center``, ``directions`` y ``radii``.
     ``cluster_id`` cae a ``label`` si el objeto no lo expone explícitamente.
     """
     if isinstance(reg, dict):
-        cid = int(reg.get("cluster_id", reg.get("label", 0)))
+        cid = reg.get("cluster_id", reg.get("label", 0))
+        try:
+            cid = int(cid)
+        except Exception:
+            pass
         label = reg.get("label", cid)
         try:
             label = int(label)
@@ -176,7 +180,11 @@ def _extract_region(reg: Any) -> Tuple[int, Any, np.ndarray, np.ndarray, np.ndar
         directions = np.asarray(reg["directions"], float)
         radii = np.asarray(reg["radii"], float)
     else:
-        cid = int(getattr(reg, "cluster_id", getattr(reg, "label")))
+        cid = getattr(reg, "cluster_id", getattr(reg, "label", 0))
+        try:
+            cid = int(cid)
+        except Exception:
+            pass
         label = getattr(reg, "label", cid)
         try:
             label = int(label)

--- a/tests/test_region_interpretability.py
+++ b/tests/test_region_interpretability.py
@@ -1,0 +1,18 @@
+# tests/test_region_interpretability.py
+import numpy as np
+from sheshe.region_interpretability import _extract_region
+
+
+def test_extract_region_label_na():
+    reg = {
+        "label": "NA",
+        "center": [0.0, 0.0],
+        "directions": np.eye(2),
+        "radii": [1.0, 1.0],
+    }
+    cid, label, center, directions, radii = _extract_region(reg)
+    assert cid == "NA"
+    assert label == "NA"
+    np.testing.assert_array_equal(center, np.array([0.0, 0.0]))
+    np.testing.assert_array_equal(directions, np.eye(2))
+    np.testing.assert_array_equal(radii, np.array([1.0, 1.0]))


### PR DESCRIPTION
## Summary
- tolerate non-integer `cluster_id`/`label` when extracting regions
- test extraction with string label `"NA"`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3d03162dc832ca88e8a7cd8600544