### PR TITLE
Handle KBinsDiscretizer quantile_method compatibility

### DIFF
--- a/src/sheshe/subspace_scout.py
+++ b/src/sheshe/subspace_scout.py
@@ -185,12 +185,23 @@ class SubspaceScout:
         if keep.size:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=UserWarning)
-                disc = KBinsDiscretizer(
-                    n_bins=bins[keep],
-                    encode="ordinal",
-                    strategy="quantile",
-                    quantile_method="linear",
-                )
+                try:
+                    disc = KBinsDiscretizer(
+                        n_bins=bins[keep],
+                        encode="ordinal",
+                        strategy="quantile",
+                        quantile_method="linear",
+                    )
+                except TypeError:
+                    # Older versions of scikit-learn do not support the
+                    # ``quantile_method`` argument.  Fall back to the default
+                    # behaviour in those cases so that discretisation still
+                    # works.
+                    disc = KBinsDiscretizer(
+                        n_bins=bins[keep],
+                        encode="ordinal",
+                        strategy="quantile",
+                    )
                 Xd_keep = disc.fit_transform(X[:, keep]).astype(int)
             Xd[:, keep] = Xd_keep
 

--- a/tests/test_subspace_scout.py
+++ b/tests/test_subspace_scout.py
@@ -26,6 +26,44 @@ def test_subspace_scout_returns_default_for_two_dims():
     }]
 
 
+def test_discretize_falls_back_without_quantile_method(monkeypatch):
+    import sheshe.subspace_scout as sc
+    from sklearn.preprocessing import KBinsDiscretizer
+
+    class OldKBinsDiscretizer(KBinsDiscretizer):
+        """Simulate an older scikit-learn without ``quantile_method``."""
+
+        def __init__(
+            self,
+            n_bins=5,
+            *,
+            encode="onehot",
+            strategy="quantile",
+            dtype=None,
+            subsample=200000,
+            random_state=None,
+        ):
+            # The parent class accepts ``quantile_method``.  By omitting it from
+            # the signature we emulate a version of scikit-learn where passing
+            # that argument would raise ``TypeError``.
+            super().__init__(
+                n_bins=n_bins,
+                encode=encode,
+                strategy=strategy,
+                dtype=dtype,
+                subsample=subsample,
+                random_state=random_state,
+            )
+
+    monkeypatch.setattr(sc, "KBinsDiscretizer", OldKBinsDiscretizer)
+    scout = sc.SubspaceScout(random_state=0)
+    X = np.random.rand(30, 3)
+    y = np.random.randint(0, 2, size=30)
+    # Should not raise even though the patched discretizer rejects
+    # ``quantile_method`` when present.
+    scout.fit(X, y)
+
+
 def test_subspace_scout_returns_default_for_one_dim():
     X = np.random.rand(50, 1)
     y = np.random.randint(0, 2, size=50)


### PR DESCRIPTION
## Summary
- handle absence of `quantile_method` argument in scikit-learn's KBinsDiscretizer
- ensure discretization falls back to default when the argument is unsupported
- add regression test covering the fallback path

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3db2624cc832c99b23e7b65a9ef81