### PR TITLE
Handle alternate region keys in interpreter

### DIFF
--- a/src/sheshe/region_interpretability.py
+++ b/src/sheshe/region_interpretability.py
@@ -176,9 +176,16 @@ def _extract_region(reg: Any) -> Tuple[Any, Any, np.ndarray, np.ndarray, np.ndar
             label = int(label)
         except Exception:
             pass
-        center = np.asarray(reg["center"], float)
-        directions = np.asarray(reg["directions"], float)
-        radii = np.asarray(reg["radii"], float)
+
+        def _pick(d, *keys):
+            for k in keys:
+                if k in d:
+                    return d[k]
+            raise KeyError(keys[0])
+
+        center = np.asarray(_pick(reg, "center", "center_", "centroid"), float)
+        directions = np.asarray(_pick(reg, "directions", "directions_", "dirs"), float)
+        radii = np.asarray(_pick(reg, "radii", "radii_", "radius"), float)
     else:
         cid = getattr(reg, "cluster_id", getattr(reg, "label", 0))
         try:
@@ -190,9 +197,16 @@ def _extract_region(reg: Any) -> Tuple[Any, Any, np.ndarray, np.ndarray, np.ndar
             label = int(label)
         except Exception:
             pass
-        center = np.asarray(getattr(reg, "center"), float)
-        directions = np.asarray(getattr(reg, "directions"), float)
-        radii = np.asarray(getattr(reg, "radii"), float)
+
+        def _pick_attr(obj, *names):
+            for n in names:
+                if hasattr(obj, n):
+                    return getattr(obj, n)
+            raise AttributeError(names[0])
+
+        center = np.asarray(_pick_attr(reg, "center", "center_", "centroid"), float)
+        directions = np.asarray(_pick_attr(reg, "directions", "directions_", "dirs"), float)
+        radii = np.asarray(_pick_attr(reg, "radii", "radii_", "radius"), float)
     return cid, label, center, directions, radii
 
 

--- a/tests/test_region_interpretability.py
+++ b/tests/test_region_interpretability.py
@@ -16,3 +16,19 @@ def test_extract_region_label_na():
     np.testing.assert_array_equal(center, np.array([0.0, 0.0]))
     np.testing.assert_array_equal(directions, np.eye(2))
     np.testing.assert_array_equal(radii, np.array([1.0, 1.0]))
+
+
+def test_extract_region_alt_keys():
+    reg = {
+        "cluster_id": 3,
+        "label": 7,
+        "center_": [1.0, 2.0],
+        "directions_": np.eye(2),
+        "radii_": [0.5, 0.25],
+    }
+    cid, label, center, directions, radii = _extract_region(reg)
+    assert cid == 3
+    assert label == 7
+    np.testing.assert_array_equal(center, np.array([1.0, 2.0]))
+    np.testing.assert_array_equal(directions, np.eye(2))
+    np.testing.assert_array_equal(radii, np.array([0.5, 0.25]))


### PR DESCRIPTION
## Summary
- support alternate field names (center_, directions_, radii_) in `_extract_region`
- add regression test for dicts with underscored keys

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b47476f444832ca1e04b096502db91