### PR TITLE
Add prediction APIs and plotting utilities

### DIFF
--- a/src/sheshe/shushu.py
+++ b/src/sheshe/shushu.py
@@ -863,8 +863,11 @@ class ShuShu:
                     ax.scatter(X[mask, i], X[mask, j], s=18, alpha=0.8, label=str(cls))
             if show_centroids and self.regions_:
                 for reg in self.regions_:
-                    ctr = np.asarray(reg.get("center"))
-                    if ctr.shape[0] > max(i, j):
+                    ctr = reg.get("center", reg.get("centroid"))
+                    if ctr is None:
+                        continue
+                    ctr = np.atleast_1d(np.asarray(ctr))
+                    if ctr.ndim == 1 and ctr.shape[0] > max(i, j):
                         ax.scatter(ctr[i], ctr[j], marker="X", s=80, color="k", label="centro")
             ax.set_xlabel(feature_names[i])
             ax.set_ylabel(feature_names[j])

--- a/tests/test_modal_scout_ensemble.py
+++ b/tests/test_modal_scout_ensemble.py
@@ -87,3 +87,20 @@ def test_modal_scout_ensemble_with_shushu():
     labels, ids = mse.predict_regions(X[:5])
     assert labels.shape == (5,)
     assert ids.shape == (5,)
+
+
+def test_modal_scout_ensemble_decision_function():
+    data = load_iris()
+    X, y = data.data, data.target
+    mse = ModalScoutEnsemble(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        random_state=0,
+        scout_kwargs={"max_order": 2, "top_m": 4, "sample_size": None},
+        cv=2,
+    )
+    mse.fit(X, y)
+    scores = mse.decision_function(X[:5])
+    assert scores.shape == (5, len(mse.classes_))
+    pred_from_scores = mse.classes_[np.argmax(scores, axis=1)]
+    assert np.array_equal(pred_from_scores, mse.predict(X[:5]))

--- a/tests/test_plot_pairs.py
+++ b/tests/test_plot_pairs.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import pytest
 from sklearn.datasets import load_iris
 from sklearn.datasets import make_regression
-from sheshe import ModalBoundaryClustering
+from sheshe import ModalBoundaryClustering, ShuShu
 
 
 def test_plot_pairs_mismatched_y_length():
@@ -51,6 +51,28 @@ def test_plot_pairs_show_centroids_toggle():
     plt.close('all')
 
     sh.plot_pairs(X, y, max_pairs=1, max_classes=1, show_centroids=False)
+    ax = plt.gcf().axes[0]
+    texts = [t.get_text() for t in ax.get_legend().get_texts()]
+    assert all("centro" not in txt for txt in texts)
+    plt.close('all')
+
+
+def test_shushu_plot_pairs_show_centroids():
+    X, y = load_iris(return_X_y=True)
+    sh = ShuShu(
+        k=5,
+        rf_estimators=5,
+        importance_sample_size=60,
+        max_iter=5,
+        random_state=0,
+    ).fit(X, y)
+    sh.plot_pairs(X, y, max_pairs=1, show_centroids=True)
+    ax = plt.gcf().axes[0]
+    texts = [t.get_text() for t in ax.get_legend().get_texts()]
+    assert any("centro" in txt for txt in texts)
+    plt.close('all')
+
+    sh.plot_pairs(X, y, max_pairs=1, show_centroids=False)
     ax = plt.gcf().axes[0]
     texts = [t.get_text() for t in ax.get_legend().get_texts()]
     assert all("centro" not in txt for txt in texts)


### PR DESCRIPTION
## Summary
- Extend CheChe with fit/predict APIs, region predictions, probability and decision functions
- Add decision_function support to ModalScoutEnsemble
- Provide plot_pairs helper for ShuShu

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b53311d654832c82d57cf87b3a6487