### PR TITLE
Standardize predictor API and region outputs

### DIFF
--- a/src/sheshe/region_interpretability.py
+++ b/src/sheshe/region_interpretability.py
@@ -69,7 +69,11 @@ def _rdp(points: np.ndarray, epsilon: float = 0.05) -> np.ndarray:
         den = np.linalg.norm(ab)
         if den < 1e-15:
             return np.linalg.norm(pt - a)
-        return abs(np.cross(ab, a - pt)) / den
+        # np.cross for 2D vectors is deprecated in NumPy 2.0; compute the
+        # equivalent scalar (z-component) manually to avoid the warning.
+        diff = a - pt
+        cross_z = ab[0] * diff[1] - ab[1] * diff[0]
+        return abs(cross_z) / den
 
     def rec(pts):
         if pts.shape[0] <= 2:

--- a/src/sheshe/subspace_scout.py
+++ b/src/sheshe/subspace_scout.py
@@ -100,12 +100,20 @@ class SubspaceScout:
         mi = np.zeros(d)
         if self.task == 'classification':
             for i in range(d):
-                mi[i] = mutual_info_classif(Xd[:, [i]], y, discrete_features=True,
-                                            random_state=self.random_state)[0]
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", category=UserWarning)
+                    mi[i] = mutual_info_classif(
+                        Xd[:, [i]], y, discrete_features=True,
+                        random_state=self.random_state
+                    )[0]
         else:
             for i in range(d):
-                mi[i] = mutual_info_regression(Xd[:, [i]], y, discrete_features=True,
-                                               random_state=self.random_state)[0]
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", category=UserWarning)
+                    mi[i] = mutual_info_regression(
+                        Xd[:, [i]], y, discrete_features=True,
+                        random_state=self.random_state
+                    )[0]
         return mi
 
     # def _mi_joint(self, Xd_cols, y, key: Tuple[int, ...]):
@@ -185,6 +193,7 @@ class SubspaceScout:
         if keep.size:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=UserWarning)
+                warnings.simplefilter("ignore", category=FutureWarning)
                 try:
                     disc = KBinsDiscretizer(
                         n_bins=bins[keep],
@@ -216,12 +225,18 @@ class SubspaceScout:
         dims = tuple(int(self._bins_per_feature[k]) for k in key)  # p.ej. (8,7,1,...)
         # ojo: si alguna dim es 1, todos los índices deben ser 0 (nuestro Xd ya lo es)
         joint = np.ravel_multi_index(Xd_cols.T, dims=dims, mode='raise').reshape(-1, 1)
-        if self.task == 'classification':
-            val = mutual_info_classif(joint, y, discrete_features=True,
-                                      random_state=self.random_state)[0]
-        else:
-            val = mutual_info_regression(joint, y, discrete_features=True,
-                                        random_state=self.random_state)[0]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            if self.task == 'classification':
+                val = mutual_info_classif(
+                    joint, y, discrete_features=True,
+                    random_state=self.random_state
+                )[0]
+            else:
+                val = mutual_info_regression(
+                    joint, y, discrete_features=True,
+                    random_state=self.random_state
+                )[0]
         self._mi_joint_cache[key] = float(val)
         return float(val)
 

--- a/tests/test_api_standardization.py
+++ b/tests/test_api_standardization.py
@@ -1,0 +1,56 @@
+import pytest
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+
+from sheshe import ShuShu, CheChe, ModalScoutEnsemble
+
+
+def test_shushu_save_load_score(tmp_path):
+    data = load_iris()
+    X, y = data.data, data.target
+    sh = ShuShu(random_state=0).fit(X, y)
+    df = sh.predict_regions(X[:3])
+    assert set(df.columns) == {"label", "region_id"}
+    assert isinstance(sh.score(X[:3], y[:3]), float)
+    with pytest.raises(NotImplementedError):
+        sh.transform(X[:3])
+    path = tmp_path / "sh.joblib"
+    sh.save(path)
+    loaded = ShuShu.load(path)
+    assert isinstance(loaded, ShuShu)
+
+
+def test_cheche_save_load_score(tmp_path):
+    data = load_iris()
+    X, y = data.data, data.target
+    ch = CheChe().fit(X, y)
+    df = ch.predict_regions(X[:2])
+    assert set(df.columns) == {"label", "region_id"}
+    assert isinstance(ch.score(X[:2], y[:2]), float)
+    with pytest.raises(NotImplementedError):
+        ch.transform(X[:2])
+    path = tmp_path / "ch.joblib"
+    ch.save(path)
+    loaded = CheChe.load(path)
+    assert isinstance(loaded, CheChe)
+
+
+def test_mse_save_load_score(tmp_path):
+    data = load_iris()
+    X, y = data.data, data.target
+    mse = ModalScoutEnsemble(
+        base_estimator=LogisticRegression(max_iter=200),
+        task="classification",
+        random_state=0,
+        scout_kwargs={"max_order": 2, "top_m": 4, "sample_size": None},
+        cv=2,
+    ).fit(X, y)
+    df = mse.predict_regions(X[:5])
+    assert set(df.columns) == {"label", "region_id"}
+    assert isinstance(mse.score(X[:5], y[:5]), float)
+    with pytest.raises(NotImplementedError):
+        mse.transform(X[:5])
+    path = tmp_path / "mse.joblib"
+    mse.save(path)
+    loaded = ModalScoutEnsemble.load(path)
+    assert isinstance(loaded, ModalScoutEnsemble)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -65,11 +65,11 @@ def test_prediction_within_region_labels():
     sh.fit(X, y)
     assert hasattr(sh, "labels_")
     assert sh.labels_.shape[0] == X.shape[0]
-    expected = sh.predict_regions(X)
-    assert np.array_equal(sh.labels_, expected)
+    df = sh.predict_regions(X)
+    assert np.array_equal(sh.labels_, df["label"].to_numpy())
     far_point = np.array([[1000, 1000, 1000, 1000]])
-    far_label = sh.predict_regions(far_point)[0]
-    assert far_label == -1
+    far_df = sh.predict_regions(far_point)
+    assert far_df.iloc[0]["label"] == -1
 
 
 def test_prediction_within_region_optional():

--- a/tests/test_cheche_module.py
+++ b/tests/test_cheche_module.py
@@ -119,10 +119,10 @@ def test_cheche_prediction_api_multiclass():
     assert proba.shape == (len(X_test), 2)
     assert np.allclose(proba.sum(axis=1), 1.0)
 
-    labels, ids = ch.predict_regions(X_test)
-    assert np.array_equal(labels, y_test)
-    assert ids.min() >= 0
+    df = ch.predict_regions(X_test)
+    assert np.array_equal(df["label"].to_numpy(), y_test)
+    assert df["region_id"].min() >= 0
 
     scores = ch.decision_function(X_test)
     assert scores.shape == (len(X_test), len(ch.regions_))
-    assert np.array_equal(np.argmax(scores, axis=1), ids)
+    assert np.array_equal(np.argmax(scores, axis=1), df["region_id"].to_numpy())

--- a/tests/test_modal_scout_ensemble.py
+++ b/tests/test_modal_scout_ensemble.py
@@ -39,13 +39,13 @@ def test_modal_scout_ensemble_prediction_within_region():
     assert hasattr(mse, "labels_")
     assert hasattr(mse, "label2id_")
     assert mse.labels_.shape[0] == X.shape[0]
-    labels, ids = mse.predict_regions(X)
-    assert np.array_equal(labels, mse.labels_)
-    assert np.array_equal(ids, mse.label2id_)
+    df = mse.predict_regions(X)
+    assert np.array_equal(df["label"].to_numpy(), mse.labels_)
+    assert np.array_equal(df["region_id"].to_numpy(), mse.label2id_)
     far_point = np.array([[1000, 1000, 1000, 1000]])
-    far_label, far_id = mse.predict_regions(far_point)
-    assert far_label[0] == -1
-    assert far_id[0] == -1
+    far_df = mse.predict_regions(far_point)
+    assert far_df.iloc[0]["label"] == -1
+    assert far_df.iloc[0]["region_id"] == -1
 
 
 def test_modal_scout_ensemble_prediction_within_region_optional():
@@ -84,9 +84,8 @@ def test_modal_scout_ensemble_with_shushu():
     assert yhat.shape == y.shape
     proba = mse.predict_proba(X[:5])
     assert proba.shape[0] == 5
-    labels, ids = mse.predict_regions(X[:5])
-    assert labels.shape == (5,)
-    assert ids.shape == (5,)
+    df = mse.predict_regions(X[:5])
+    assert df.shape == (5, 2)
 
 
 def test_modal_scout_ensemble_decision_function():

--- a/tests/test_region_interpretability.py
+++ b/tests/test_region_interpretability.py
@@ -1,6 +1,7 @@
 # tests/test_region_interpretability.py
 import numpy as np
-from sheshe.region_interpretability import _extract_region
+import warnings
+from sheshe.region_interpretability import _extract_region, _rdp
 
 
 def test_extract_region_label_na():
@@ -32,3 +33,13 @@ def test_extract_region_alt_keys():
     np.testing.assert_array_equal(center, np.array([1.0, 2.0]))
     np.testing.assert_array_equal(directions, np.eye(2))
     np.testing.assert_array_equal(radii, np.array([0.5, 0.25]))
+
+
+def test_rdp_no_deprecation_warning():
+    pts = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [2.0, 1.0]])
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        simplified = _rdp(pts, epsilon=0.01)
+    assert not any(issubclass(warn.category, DeprecationWarning) for warn in w)
+    assert simplified.shape[1] == 2
+    assert simplified.shape[0] >= 2

--- a/tests/test_shushu_module.py
+++ b/tests/test_shushu_module.py
@@ -29,8 +29,8 @@ def test_shushu_clusterer_basic():
     assert isinstance(cl.regions_, list)
     labels = cl.predict(X[:3])
     assert labels.shape == (3,)
-    labels2, ids2 = cl.predict_regions(X[:3])
-    assert np.array_equal(labels2, ids2)
+    df2 = cl.predict_regions(X[:3])
+    assert np.array_equal(df2["label"].to_numpy(), df2["region_id"].to_numpy())
 
 
 def test_shushu_multiclass_basic():
@@ -48,9 +48,8 @@ def test_shushu_multiclass_basic():
     assert yhat.shape == y.shape
     proba = sh.predict_proba(X[:5])
     assert np.allclose(proba.sum(axis=1), 1.0)
-    labels, ids = sh.predict_regions(X[:5])
-    assert labels.shape == (5,)
-    assert ids.shape == (5,)
+    df = sh.predict_regions(X[:5])
+    assert df.shape == (5, 2)
     assert hasattr(sh, "regions_")
     assert isinstance(sh.regions_, list)
 


### PR DESCRIPTION
## Summary
- standardize scikit-learn style API for ModalBoundaryClustering, ShuShu, CheChe, and ModalScoutEnsemble
- return pandas DataFrames from `predict_regions` and support joblib-based save/load with version checks
- add scoring helpers and NotImplemented stubs for unsupported transform operations
- avoid NumPy 2D `np.cross` deprecation in region interpretability and add regression test
- silence scikit-learn warnings in SubspaceScout and use `accuracy_score` in `ModalScoutEnsemble.score`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c80805cc832cbe397c1e900a55c6