### PR TITLE
Implement transform and scoring in ShuShu

### DIFF
--- a/tests/test_api_standardization.py
+++ b/tests/test_api_standardization.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 from sklearn.datasets import load_iris
 from sklearn.linear_model import LogisticRegression
 
@@ -12,8 +13,9 @@ def test_shushu_save_load_score(tmp_path):
     df = sh.predict_regions(X[:3])
     assert set(df.columns) == {"label", "region_id"}
     assert isinstance(sh.score(X[:3], y[:3]), float)
-    with pytest.raises(NotImplementedError):
-        sh.transform(X[:3])
+    T = sh.transform(X[:3])
+    assert T.shape[0] == 3
+    assert np.allclose(T.sum(axis=1), 1.0)
     path = tmp_path / "sh.joblib"
     sh.save(path)
     loaded = ShuShu.load(path)


### PR DESCRIPTION
## Summary
- implement `transform`, `fit_transform`, and `get_cluster` in ShuShu with caching and geometry summaries
- add flexible `score` supporting custom metrics like `f1_macro`
- extend tests for new transform and scoring behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b610950ce4832c85bb87e4688f5ac4