### PR TITLE
Handle missing region geometry in RegionInterpreter

### DIFF
--- a/tests/test_region_interpretability.py
+++ b/tests/test_region_interpretability.py
@@ -1,7 +1,7 @@
 # tests/test_region_interpretability.py
 import numpy as np
 import warnings
-from sheshe.region_interpretability import _extract_region, _rdp
+from sheshe.region_interpretability import _extract_region, _rdp, RegionInterpreter
 
 
 def test_extract_region_label_na():
@@ -34,6 +34,37 @@ def test_extract_region_alt_keys():
     np.testing.assert_array_equal(directions, np.eye(2))
     np.testing.assert_array_equal(radii, np.array([0.5, 0.25]))
 
+
+def test_extract_region_missing_directions():
+    reg = {
+        "center": [0.0, 0.0],
+        "radii": [1.0, 2.0],
+    }
+    cid, label, center, directions, radii = _extract_region(reg)
+    assert cid == 0 and label == 0
+    assert directions.shape == (4, 2)
+    np.testing.assert_array_equal(radii, np.array([1.0, 2.0, 1.0, 2.0]))
+
+
+def test_extract_region_inflection_fallback():
+    center = [0.0, 0.0]
+    infl = np.array([[1.0, 0.0], [0.0, 2.0], [-1.0, 0.0], [0.0, -2.0]])
+    reg = {"center": center, "inflection_points": infl}
+    cid, label, center_out, directions, radii = _extract_region(reg)
+    assert cid == 0 and label == 0
+    np.testing.assert_array_almost_equal(center_out, np.array(center))
+    expected_dirs = np.array([[1, 0], [0, 1], [-1, 0], [0, -1]], float)
+    np.testing.assert_array_almost_equal(directions, expected_dirs)
+    np.testing.assert_array_almost_equal(radii, np.array([1.0, 2.0, 1.0, 2.0]))
+
+
+def test_summarize_with_inflection_only():
+    center = [0.0, 0.0]
+    infl = np.array([[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]])
+    reg = {"center": center, "inflection_points": infl}
+    card = RegionInterpreter(feature_names=["x", "y"]).summarize(reg)[0]
+    assert card["headline"] != "Región degenerada (sin radios útiles)."
+    assert card["box_rules"] == ["x ∈ [-0.8, 0.8]", "y ∈ [-0.8, 0.8]"]
 
 def test_rdp_no_deprecation_warning():
     pts = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [2.0, 1.0]])


### PR DESCRIPTION
## Summary
- Allow RegionInterpreter to reconstruct directions and radii from `inflection_points` when not provided.
- Add tests ensuring regions without explicit geometry still produce interpretable descriptions.

## Testing
- `PYTHONPATH=src pytest tests/test_region_interpretability.py -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b64132e4fc832c9620bad51f659d74