### PR TITLE
Serve GitHub Pages docs in HTML format

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+title: SheShe Documentation
+description: Official documentation for the SheShe library
+remote_theme: just-the-docs/just-the-docs

--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -1,0 +1,70 @@
+---
+layout: default
+title: CheChe
+parent: SheShe
+nav_order: 6
+---
+<link rel="stylesheet" href="style.css">
+
+<h1>CheChe</h1>
+
+<figure class="doc-image">
+  <img src="images/cheche.png" alt="CheChe diagram">
+</figure>
+<p>Computes convex-hull frontiers for selected feature pairs and provides simple</p>
+<p>2D visualisations.</p>
+<h2>Example</h2>
+<pre><code>
+from sheshe import CheChe
+cc = CheChe()
+cc.fit(X, y)
+cc.plot_pairs(X)
+</code></pre>
+<h2>Parameters</h2>
+<ul>
+<li><code>random_state</code> (<code>int</code> or <code>None</code>, default <code>None</code>): seed for reproducibility.
+</li>
+</ul>
+<h3>Fit-time options</h3>
+<p>The <code>fit</code> method accepts additional arguments mirroring the <code>ShuShu</code> API:</p>
+<ul>
+<li><code>score_fn</code> (callable, optional): scalar score function when <code>y</code> is not
+ provided.
+</li>
+<li><code>feature_names</code> (<code>list[str]</code> or <code>None</code>): names for features.
+</li>
+<li><code>score_model</code> (estimator, optional): model used to derive class probabilities.
+</li>
+<li><code>score_fn_multi</code> (<code>callable</code>, optional): multi-class score function.
+</li>
+<li><code>score_fn_per_class</code> (<code>list[callable]</code>, optional): per-class score functions.
+</li>
+<li><code>max_pairs</code> (<code>int</code> or <code>None</code>, default <code>10</code>): maximum number of feature pairs
+ to analyse.
+</li>
+<li><code>mapping_level</code> (<code>int</code> or <code>None</code>, default <code>None</code>): down-sampling level for
+ frontier computation.
+</li>
+</ul>
+<h2>Methods</h2>
+<ul>
+<li><code>fit(X, y=None, **kwargs)</code> – estimate 2D frontiers for feature pairs.
+</li>
+<li><code>fit_predict(X, y=None, **kwargs)</code> – fit the model and immediately return
+ predictions.
+</li>
+<li><code>predict(X)</code> – assign region ids or class labels.
+</li>
+<li><code>predict_proba(X)</code> – return class probabilities in multiclass mode.
+</li>
+<li><code>predict_regions(X)</code> – DataFrame with labels and region ids.
+</li>
+<li><code>decision_function(X)</code> – negative distances to region centres.
+</li>
+<li><code>plot_pairs(X, class_index=None, feature_names=None)</code> – scatter plots with
+ frontier overlays for stored pairs.
+</li>
+<li><code>plot_classes(X, y, ...)</code> – plot frontiers for each class when in supervised
+ mode.
+</li>
+</ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,50 @@
+---
+layout: default
+title: SheShe
+nav_order: 1
+has_children: true
+---
+
+<link rel="stylesheet" href="style.css">
+
+<h1>SheShe</h1>
+
+<figure class="doc-image">
+  <img src="images/overview.png" alt="SheShe overview diagram">
+</figure>
+
+<p>Smart High-dimensional Edge Segmentation &amp; Hyperboundary Explorer</p>
+
+<p>SheShe converts any probabilistic model into an explorer of its own decision landscape. It follows local maxima of class probability or predicted value to uncover crisp, human‑readable regions that respect the supervised boundary of the problem.</p>
+
+<h2>Getting started</h2>
+
+<p>Install the library and run the basic tests:</p>
+
+<pre><code>pip install sheshe
+PYTHONPATH=src pytest tests/test_basic.py::test_import_and_fit -q
+</code></pre>
+
+<h2>Predictors</h2>
+
+<p>The project exposes several predictors and utilities. Each section below describes one of them in more detail:</p>
+
+<ul>
+  <li><a href="modalboundaryclustering.html">ModalBoundaryClustering</a></li>
+  <li><a href="subspacescout.html">SubspaceScout</a></li>
+  <li><a href="modalscoutensemble.html">ModalScoutEnsemble</a></li>
+  <li><a href="regioninterpreter.html">RegionInterpreter</a></li>
+  <li><a href="shushu.html">ShuShu</a></li>
+  <li><a href="cheche.html">CheChe</a></li>
+</ul>
+
+<h2>Contribute</h2>
+
+<p>Improvements are welcome! Fork the repository, install development dependencies, and run the tests:</p>
+
+<pre><code>pip install -e ".[dev]"
+PYTHONPATH=src pytest -q
+</code></pre>
+
+<p>Released under the MIT License.</p>
+

--- a/docs/modalboundaryclustering.html
+++ b/docs/modalboundaryclustering.html
@@ -1,0 +1,168 @@
+---
+layout: default
+title: ModalBoundaryClustering
+parent: SheShe
+nav_order: 1
+---
+<link rel="stylesheet" href="style.css">
+
+<h1>ModalBoundaryClustering</h1>
+
+<figure class="doc-image">
+  <img src="images/modalboundaryclustering.png" alt="ModalBoundaryClustering diagram">
+</figure>
+<p>Learns regions of high probability or predicted value by climbing local maxima of a</p>
+<p>base estimator.</p>
+<h2>Example</h2>
+<pre><code>
+from sheshe import ModalBoundaryClustering
+mbc = ModalBoundaryClustering()
+mbc.fit(X, y)
+labels = mbc.predict(X)
+</code></pre>
+<h2>Parameters</h2>
+<ul>
+<li><code>base_estimator</code> (BaseEstimator, default <code>None</code>): model used to compute
+ probabilities or predictions. Defaults to <code>LogisticRegression</code> when <code>None</code>.
+</li>
+<li><code>task</code> (<code>str</code>, default <code>"classification"</code>): "classification" or
+ "regression".
+</li>
+<li><code>base_2d_rays</code> (<code>int</code>, default <code>32</code>): number of radial directions in 2D;
+ automatically reduced for high-dimensional data when <code>auto_rays_by_dim</code> is
+ <code>True</code>.
+</li>
+<li><code>direction</code> (<code>{"center_out", "outside_in"}</code>, default <code>"center_out"</code>):
+ direction used to locate inflection points along each ray.
+</li>
+<li><code>stop_criteria</code> (<code>{"inflexion", "percentile"}</code>, default <code>"inflexion"</code>):
+ rule to stop radial expansion.
+</li>
+<li><code>percentile_bins</code> (<code>int</code>, default <code>20</code>): bins for percentile-based stopping.
+</li>
+<li><code>scan_radius_factor</code> (<code>float</code>, default <code>3.0</code>): maximum scan radius as a
+ multiple of the global standard deviation.
+</li>
+<li><code>scan_steps</code> (<code>int</code>, default <code>24</code>): number of steps sampled along each ray.
+</li>
+<li><code>smooth_window</code> (<code>int</code> or <code>None</code>, default <code>None</code>): moving-average window to
+ smooth radial scans.
+</li>
+<li><code>drop_fraction</code> (<code>float</code>, default <code>0.5</code>): fallback drop from the peak when no
+ inflection is found.
+</li>
+<li><code>bounds_margin</code> (<code>float</code>, default <code>0.05</code>): margin added to data bounds to
+ avoid clipping during scans.
+</li>
+<li><code>grad_lr</code> (<code>float</code>, default <code>0.2</code>): learning rate for gradient ascent.
+</li>
+<li><code>grad_max_iter</code> (<code>int</code>, default <code>80</code>): maximum iterations for gradient
+ ascent.
+</li>
+<li><code>grad_tol</code> (<code>float</code>, default <code>1e-5</code>): tolerance on gradient norm to stop the
+ ascent.
+</li>
+<li><code>grad_eps</code> (<code>float</code>, default <code>1e-3</code>): finite-difference step for gradients.
+</li>
+<li><code>optim_method</code> (<code>str</code>, default <code>"gradient_ascent"</code>): optimisation strategy;
+ accepts <code>"gradient_ascent"</code> or <code>"trust_region_newton"</code>.
+</li>
+<li><code>n_max_seeds</code> (<code>int</code>, default <code>2</code>): number of random starting points.
+</li>
+<li><code>random_state</code> (<code>int</code>, default <code>42</code>): seed for reproducibility.
+</li>
+<li><code>percentile_sample_size</code> (<code>int</code>, default <code>50000</code>): sample size to compute
+ percentile thresholds.
+</li>
+<li><code>max_subspaces</code> (<code>int</code>, default <code>20</code>): maximum subspaces explored when
+ <code>X</code> has more than three dimensions.
+</li>
+<li><code>verbose</code> (<code>int</code>, default <code>0</code>): logging level; <code>0</code> silent, <code>1</code> summary,
+ <code>2</code> detailed.
+</li>
+<li><code>save_labels</code> (<code>bool</code>, default <code>False</code>): store label assignments to disk.
+</li>
+<li><code>prediction_within_region</code> (<code>bool</code>, default <code>False</code>): evaluate the base
+ estimator only within each region before predicting.
+</li>
+<li><code>out_dir</code> (<code>str</code> or <code>Path</code>, optional): directory where auxiliary files are
+ written.
+</li>
+<li><code>auto_rays_by_dim</code> (<code>bool</code>, default <code>True</code>): automatically reduce the number
+ of rays in high dimension.
+</li>
+<li><code>ray_mode</code> (<code>str</code>, default <code>"grad"</code>): strategy used to generate candidate
+ rays.
+</li>
+<li><code>use_spsa</code> (<code>bool</code>, default <code>True</code>): use SPSA for gradient estimates when
+ analytical gradients are unavailable.
+</li>
+<li><code>spsa_delta</code> (<code>float</code>, default <code>1e-2</code>): SPSA perturbation size.
+</li>
+<li><code>spsa_avg</code> (<code>int</code>, default <code>4</code>): number of SPSA evaluations per gradient
+ estimate.
+</li>
+<li><code>ls_alpha0</code> (<code>float</code>, default <code>0.5</code>): initial step size for line search.
+</li>
+<li><code>ls_shrink</code> (<code>float</code>, default <code>0.5</code>): multiplicative shrink factor during
+ line search.
+</li>
+<li><code>ls_min_alpha</code> (<code>float</code>, default <code>1e-3</code>): minimum allowed step size.
+</li>
+<li><code>arc_max_steps</code> (<code>int</code>, default <code>64</code>): maximum steps for arc exploration.
+</li>
+<li><code>arc_len_max</code> (<code>float</code>, default <code>3.0</code>): maximum arc length.
+</li>
+<li><code>line_refine_steps</code> (<code>int</code>, default <code>8</code>): refinement steps when mapping
+ boundaries.
+</li>
+<li><code>use_adaptive_scan</code> (<code>bool</code> or <code>None</code>, default <code>None</code>): enable adaptive
+ radial scan when dimensionality is high.
+</li>
+<li><code>batch_size</code> (<code>int</code>, default <code>16384</code>): batch size for model evaluations.
+</li>
+<li><code>coarse_steps</code> (<code>int</code>, default <code>12</code>): number of coarse scan steps in high
+ dimension.
+</li>
+<li><code>refine_steps</code> (<code>int</code>, default <code>4</code>): number of refinement steps after the
+ coarse scan.
+</li>
+<li><code>early_exit_patience</code> (<code>int</code>, default <code>1</code>): early termination patience for
+ flat regions.
+</li>
+<li><code>density_alpha</code> (<code>float</code>, default <code>0.0</code>): exponent for density penalty.
+</li>
+<li><code>density_k</code> (<code>int</code>, default <code>15</code>): neighbour count for density estimation.
+</li>
+<li><code>cluster_metrics_cls</code> (<code>dict</code> or <code>None</code>): callbacks to evaluate clusters in
+ classification mode.
+</li>
+<li><code>cluster_metrics_reg</code> (<code>dict</code> or <code>None</code>): callbacks for regression mode.
+</li>
+<li><code>fast_membership</code> (<code>bool</code>, default <code>False</code>): enable approximate membership
+ computation.
+</li>
+</ul>
+<h2>Methods</h2>
+<ul>
+<li><code>fit(X, y)</code> – learn regions from data and labels.
+</li>
+<li><code>predict(X)</code> – assign cluster ids to samples.
+</li>
+<li><code>fit_predict(X, y=None)</code> – convenience wrapper around <code>fit</code> + <code>predict</code>.
+</li>
+<li><code>predict_proba(X)</code> – return per-cluster probabilities.
+</li>
+<li><code>decision_function(X)</code> – base-estimator decision scores.
+</li>
+<li><code>predict_regions(X, label_path=None)</code> – cluster ids and optional label dump.
+</li>
+<li><code>interpretability_summary(feature_names=None)</code> – tabular region summary.
+</li>
+<li><code>plot_pairs(X, y=None, max_pairs=None)</code> – 2D decision plots for feature
+ pairs.
+</li>
+<li><code>plot_pair_3d(X, pair, class_label=None, grid_res=50, alpha_surface=0.6,
+ engine="matplotlib")</code> – render a 3D surface for a feature pair.
+</li>
+</ul>

--- a/docs/modalscoutensemble.html
+++ b/docs/modalscoutensemble.html
@@ -1,0 +1,115 @@
+---
+layout: default
+title: ModalScoutEnsemble
+parent: SheShe
+nav_order: 3
+---
+<link rel="stylesheet" href="style.css">
+
+<h1>ModalScoutEnsemble</h1>
+
+<figure class="doc-image">
+  <img src="images/modalscoutensemble.png" alt="ModalScoutEnsemble diagram">
+</figure>
+<p>Ensemble that applies <code>ModalBoundaryClustering</code> on the most promising</p>
+<p>subspaces discovered by <code>SubspaceScout</code>.</p>
+<h2>Example</h2>
+<pre><code>
+from sheshe import ModalScoutEnsemble
+from sklearn.linear_model import LogisticRegression
+mse = ModalScoutEnsemble(base_estimator=LogisticRegression())
+mse.fit(X, y)
+labels = mse.predict(X)
+</code></pre>
+<h2>Parameters</h2>
+<ul>
+<li><code>base_estimator</code> (<code>BaseEstimator</code>): model used to compute probabilities or
+ predictions in each subspace.
+</li>
+<li><code>task</code> (<code>str</code>, optional): "classification" or "regression". Inferred from the
+ base estimator if <code>None</code>.
+</li>
+<li><code>ensemble_method</code> (<code>str</code>, default <code>"modal_scout"</code>): either <code>"modal_scout"</code>
+ to use the internal subspace ensemble or <code>"shushu"</code> to delegate to
+ <code>ShuShu</code>.
+</li>
+<li><code>top_k</code> (<code>int</code>, default <code>8</code>): maximum number of subspaces kept.
+</li>
+<li><code>min_score</code> (<code>float</code> or <code>None</code>): minimum score required for a subspace to be
+ used.
+</li>
+<li><code>max_order</code> (<code>int</code> or <code>None</code>): maximum order of subspaces evaluated.
+</li>
+<li><code>metric</code> (<code>str</code> or <code>None</code>, default <code>"mi_synergy"</code>): criterion used to rank
+ subspaces.
+</li>
+<li><code>jaccard_threshold</code> (<code>float</code>, default <code>0.55</code>): minimum Jaccard similarity to
+ consider two subspaces redundant.
+</li>
+<li><code>alpha</code> (<code>float</code>, default <code>0.5</code>): exponent for the scout score in the final
+ weighting.
+</li>
+<li><code>beta</code> (<code>float</code>, default <code>0.5</code>): exponent for cross‑validation performance.
+</li>
+<li><code>gamma</code> (<code>float</code>, default <code>0.5</code>): exponent for global feature importance.
+</li>
+<li><code>cv</code> (<code>int</code> or <code>None</code>, default <code>3</code>): number of CV folds; <code>0</code> or <code>None</code> uses a
+ holdout split.
+</li>
+<li><code>cv_metric_cls</code> (<code>Callable</code>, default <code>balanced_accuracy_score</code>): metric for
+ classification CV.
+</li>
+<li><code>cv_metric_reg</code> (<code>Callable</code>, default <code>r2_score</code>): metric for regression CV.
+</li>
+<li><code>cv_floor</code> (<code>float</code> or <code>None</code>): discard subspaces with CV below this value.
+</li>
+<li><code>n_jobs</code> (<code>int</code>, default <code>1</code>): number of parallel jobs for CV.
+</li>
+<li><code>random_state</code> (<code>int</code> or <code>None</code>, default <code>0</code>): RNG seed.
+</li>
+<li><code>base_2d_rays</code> (<code>int</code>, default <code>8</code>): base number of rays for MBC fits in each
+ subspace.
+</li>
+<li><code>ray_cap</code> (<code>int</code>, default <code>48</code>): maximum rays allowed per subspace.
+</li>
+<li><code>time_budget_s</code> (<code>float</code> or <code>None</code>): optional global time budget for fitting.
+</li>
+<li><code>use_importances</code> (<code>bool</code>, default <code>True</code>): include global feature
+ importances in the weighting.
+</li>
+<li><code>importance_sample_size</code> (<code>int</code> or <code>None</code>, default <code>4096</code>): sample size for
+ computing global importances.
+</li>
+<li><code>scout_kwargs</code> (<code>dict</code> or <code>None</code>): parameters forwarded to <code>SubspaceScout</code>.
+</li>
+<li><code>shushu_kwargs</code> (<code>dict</code> or <code>None</code>): parameters forwarded to <code>ShuShu</code> when
+ <code>ensemble_method="shushu"</code>.
+</li>
+<li><code>mbc_kwargs</code> (<code>dict</code> or <code>None</code>): additional arguments passed to each
+ <code>ModalBoundaryClustering</code> instance.
+</li>
+<li><code>verbose</code> (<code>int</code>, default <code>0</code>): logging level.
+</li>
+<li><code>prediction_within_region</code> (<code>bool</code>, default <code>False</code>): evaluate base estimator
+ only within each region during prediction.
+</li>
+</ul>
+<h2>Methods</h2>
+<ul>
+<li><code>fit(X, y)</code> – train the ensemble on <code>X</code> and <code>y</code>.
+</li>
+<li><code>predict(X)</code> – predict labels or cluster ids.
+</li>
+<li><code>predict_proba(X)</code> – class probabilities aggregated across subspaces.
+</li>
+<li><code>decision_function(X)</code> – decision scores averaged across submodels.
+</li>
+<li><code>predict_regions(X)</code> – DataFrame with region assignments.
+</li>
+<li><code>plot_pairs(X, y=None, **kwargs)</code> – delegate to
+ <code>ModalBoundaryClustering.plot_pairs</code> for a selected submodel.
+</li>
+<li><code>plot_pair_3d(X, pair, **kwargs)</code> – 3D surface for a feature pair of a
+ submodel.
+</li>
+</ul>

--- a/docs/regioninterpreter.html
+++ b/docs/regioninterpreter.html
@@ -1,0 +1,55 @@
+---
+layout: default
+title: RegionInterpreter
+parent: SheShe
+nav_order: 4
+---
+<link rel="stylesheet" href="style.css">
+
+<h1>RegionInterpreter</h1>
+
+<figure class="doc-image">
+  <img src="images/regioninterpreter.png" alt="RegionInterpreter diagram">
+</figure>
+<p>Converts <code>ClusterRegion</code> objects into compact human‑readable rule sets.</p>
+<h2>Example</h2>
+<pre><code>
+from sheshe import RegionInterpreter
+ri = RegionInterpreter(feature_names=["sepal", "petal"])
+summary = ri.summarize(region)
+</code></pre>
+<h2>Parameters</h2>
+<ul>
+<li><code>feature_names</code> (<code>list[str]</code> or <code>None</code>, default <code>None</code>): names for each
+ feature used in the generated rules.
+</li>
+<li><code>q_box</code> (<code>float</code>, default <code>0.05</code>): quantile used to compute robust axis-aligned
+ boxes.
+</li>
+<li><code>k_pairs</code> (<code>int</code>, default <code>2</code>): number of informative 2D projections to
+ include.
+</li>
+<li><code>decimals</code> (<code>int</code>, default <code>2</code>): decimal precision in the emitted rules.
+</li>
+<li><code>cap_threshold</code> (<code>float</code>, default <code>6.393</code>): z-score threshold to mark capped
+ radii.
+</li>
+<li><code>near_const_tol</code> (<code>float</code>, default <code>0.12</code>): tolerance to report nearly constant
+ dimensions.
+</li>
+<li><code>inverse_transform</code> (callable, optional): function applied to points before
+ rule extraction (e.g. inverse scaling).
+</li>
+<li><code>feature_bounds</code> (<code>Sequence[Tuple[float, float]]</code> or <code>None</code>): hard bounds for
+ each feature to clamp boxes.
+</li>
+<li><code>include_center_in_box</code> (<code>bool</code>, default <code>True</code>): include region centre when
+ computing axis-aligned boxes.
+</li>
+</ul>
+<h2>Methods</h2>
+<ul>
+<li><code>summarize(regions)</code> – return a list of dictionaries containing headlines,
+ axis-aligned rules and pairwise projections for the provided regions.
+</li>
+</ul>

--- a/docs/shushu.html
+++ b/docs/shushu.html
@@ -1,0 +1,64 @@
+---
+layout: default
+title: ShuShu
+parent: SheShe
+nav_order: 5
+---
+<link rel="stylesheet" href="style.css">
+
+<h1>ShuShu</h1>
+
+<figure class="doc-image">
+  <img src="images/shushu.png" alt="ShuShu diagram">
+</figure>
+<p>Gradient-based optimiser that searches for local maxima of a scalar score or</p>
+<p>class probabilities.</p>
+<h2>Example</h2>
+<pre><code>
+from sheshe import ShuShu
+ss = ShuShu()
+ss.fit(X, y)
+labels = ss.predict(X)
+</code></pre>
+<h2>Parameters</h2>
+<ul>
+<li><code>clusterer_factory</code> (callable or <code>None</code>, default <code>None</code>): factory returning
+ the internal optimiser. When <code>None</code> a default implementation is used.
+</li>
+<li><code>random_state</code> (<code>int</code> or <code>None</code>, default <code>None</code>): seed for reproducibility.
+</li>
+<li><code>**clusterer_kwargs</code> – additional arguments forwarded to the internal
+ optimiser.
+</li>
+</ul>
+<h2>Methods</h2>
+<ul>
+<li><code>fit(X, y=None, score_fn=None, ...)</code> – fit the optimiser. When <code>y</code> is
+ provided, the score function is learned per class; otherwise <code>score_fn</code>
+ must be supplied.
+</li>
+<li><code>fit_predict(X, y=None, **kwargs)</code> – convenience wrapper calling <code>fit</code> then
+ <code>predict</code>.
+</li>
+<li><code>predict(X)</code> – return class labels or cluster ids.
+</li>
+<li><code>predict_proba(X)</code> – class probabilities (after fitting with labels).
+</li>
+<li><code>decision_function(X)</code> – raw decision scores.
+</li>
+<li><code>transform(X)</code> – membership/affinity matrix.
+</li>
+<li><code>fit_transform(X, y=None, **kwargs)</code> – combine <code>fit</code> and <code>transform</code>.
+</li>
+<li><code>plot_pairs(X, y=None, max_pairs=None)</code> – scatter plots for feature pairs.
+</li>
+<li><code>plot_classes(X, y, grid_res=200, contour_levels=None, max_paths=20,
+ show_paths=True)</code> – visualise class-wise score surfaces.
+</li>
+<li><code>plot_pair_3d(X, y=None, features=(i, j), ax=None, fig=None, grid=64)</code> – 3D
+ surface rendering of the score function.
+</li>
+<li><code>get_cluster(cluster_id, with_geometry=False)</code> – retrieve information about a
+ discovered cluster.
+</li>
+</ul>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,33 @@
+body {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
+  background-color: #fdfdfd;
+  color: #333;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+h1, h2, h3 {
+  color: #003b5c;
+}
+
+pre {
+  background: #f0f0f0;
+  padding: 1rem;
+  overflow-x: auto;
+  border-radius: 4px;
+}
+
+.doc-image {
+  text-align: center;
+  margin: 2rem 0;
+}
+
+.doc-image img {
+  max-width: 100%;
+  height: auto;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}

--- a/docs/subspacescout.html
+++ b/docs/subspacescout.html
@@ -1,0 +1,82 @@
+---
+layout: default
+title: SubspaceScout
+parent: SheShe
+nav_order: 2
+---
+<link rel="stylesheet" href="style.css">
+
+<h1>SubspaceScout</h1>
+
+<figure class="doc-image">
+  <img src="images/subspacescout.png" alt="SubspaceScout diagram">
+</figure>
+<p>Identifies informative feature subsets so that <code>ModalBoundaryClustering</code> can</p>
+<p>run only where it matters in high-dimensional spaces.</p>
+<h2>Example</h2>
+<pre><code>
+from sheshe import SubspaceScout
+scout = SubspaceScout()
+scout.fit(X, y)
+subspaces = scout.results_
+</code></pre>
+<h2>Parameters</h2>
+<ul>
+<li><code>model_method</code> (<code>None</code> or <code>"lightgbm"</code> or <code>"ebm"</code>, default <code>None</code>): model
+ used to score subspaces. <code>None</code> uses mutual information.
+</li>
+<li><code>max_order</code> (<code>int</code>, default <code>3</code>): maximum size of feature combinations to
+ explore.
+</li>
+<li><code>n_bins</code> (<code>int</code>, default <code>8</code>): number of bins for discretising features.
+</li>
+<li><code>top_m</code> (<code>int</code>, default <code>20</code>): number of features pre-selected by individual
+ mutual information.
+</li>
+<li><code>branch_per_parent</code> (<code>int</code>, default <code>5</code>): maximum extensions generated per
+ parent subspace.
+</li>
+<li><code>density_occup_min</code> (<code>float</code>, default <code>0.03</code>): minimum occupancy ratio for a
+ subspace to be valid.
+</li>
+<li><code>min_support</code> (<code>int</code>, default <code>30</code>): minimum number of samples required in a
+ subspace.
+</li>
+<li><code>sample_size</code> (<code>int</code> or <code>None</code>, default <code>4096</code>): optional subsampling size to
+ accelerate computations.
+</li>
+<li><code>task</code> (<code>"classification"</code> or <code>"regression"</code>, default <code>"classification"</code>):
+ learning task.
+</li>
+<li><code>random_state</code> (<code>int</code>, default <code>0</code>): seed for reproducibility.
+</li>
+<li><code>base_pairs_limit</code> (<code>int</code>, default <code>12</code>): maximum number of seed pairs for
+ higher-order searches.
+</li>
+<li><code>beam_width</code> (<code>int</code>, default <code>12</code>): number of candidates retained at each
+ order during beam search.
+</li>
+<li><code>extend_candidate_pool</code> (<code>int</code> or <code>None</code>, default <code>16</code>): random candidate
+ features sampled per parent when order ≥3.
+</li>
+<li><code>marginal_gain_min</code> (<code>float</code>, default <code>1e-3</code>): minimum synergy gain required
+ to accept an extension.
+</li>
+<li><code>max_eval_per_order</code> (<code>int</code> or <code>None</code>, default <code>1000</code>): cap on mutual
+ information evaluations per order.
+</li>
+<li><code>time_budget_s</code> (<code>float</code> or <code>None</code>, default <code>None</code>): global time budget in
+ seconds for <code>fit</code>.
+</li>
+<li><code>objective</code> (<code>"mi_joint"</code> or <code>"mi_synergy"</code>, default <code>"mi_joint"</code>): score
+ used to rank subspaces.
+</li>
+<li><code>min_per_order</code> (<code>int</code>, default <code>1</code>): minimum number of subspaces to keep per
+ order.
+</li>
+</ul>
+<h2>Methods</h2>
+<ul>
+<li><code>fit(X, y)</code> – discover subspaces and store them in <code>results_</code>.
+</li>
+</ul>


### PR DESCRIPTION
## Summary
- switch project documentation to raw HTML pages for GitHub Pages
- include detailed parameter references and method lists for each predictor
- add custom CSS styling and image placeholders for a more polished layout

## Testing
- `PYTHONPATH=src pytest tests/test_basic.py::test_import_and_fit -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6619ff7d8832cb2ca1fdbbbd12c90