### PR TITLE
docs: expand predictor examples and fix page layout

### DIFF
--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -20,6 +20,21 @@ cc = CheChe()
 cc.fit(X, y)
 cc.plot_pairs(X)
 </code></pre>
+
+<h2>Usage examples</h2>
+<pre><code>
+from sheshe import CheChe
+
+che = CheChe(random_state=0)
+che.fit(X, y)                      # fit
+che.fit_predict(X, y)              # fit_predict
+che.fit(X, y).predict(X)           # predict
+che.fit(X, y).predict_proba(X)     # predict_proba
+che.fit(X, y).predict_regions(X)   # predict_regions
+che.fit(X, y).decision_function(X) # decision_function
+che.fit(X, y).save("che.joblib")   # save
+CheChe.load("che.joblib")
+</code></pre>
 <h2>Parameters</h2>
 <ul>
 <li><code>random_state</code> (<code>int</code> or <code>None</code>, default <code>None</code>): seed for reproducibility.

--- a/docs/modalboundaryclustering.html
+++ b/docs/modalboundaryclustering.html
@@ -20,6 +20,24 @@ mbc = ModalBoundaryClustering()
 mbc.fit(X, y)
 labels = mbc.predict(X)
 </code></pre>
+
+<h2>Usage examples</h2>
+<pre><code>
+from sheshe import ModalBoundaryClustering
+
+mbc = ModalBoundaryClustering(random_state=0)
+mbc.fit(X, y)                      # fit
+mbc.fit_predict(X, y)              # fit_predict
+mbc.fit_transform(X, y)            # fit_transform
+mbc.fit(X, y).transform(X)         # transform
+mbc.fit(X, y).predict(X)           # predict
+mbc.fit(X, y).predict_proba(X)     # predict_proba
+mbc.fit(X, y).decision_function(X) # decision_function
+mbc.fit(X, y).predict_regions(X)   # predict_regions
+mbc.fit(X, y).score(X, y)          # score
+mbc.fit(X, y).save("mbc.joblib")   # save
+ModalBoundaryClustering.load("mbc.joblib")
+</code></pre>
 <h2>Parameters</h2>
 <ul>
 <li><code>base_estimator</code> (BaseEstimator, default <code>None</code>): model used to compute

--- a/docs/modalscoutensemble.html
+++ b/docs/modalscoutensemble.html
@@ -21,6 +21,25 @@ mse = ModalScoutEnsemble(base_estimator=LogisticRegression())
 mse.fit(X, y)
 labels = mse.predict(X)
 </code></pre>
+
+<h2>Usage examples</h2>
+<pre><code>
+from sheshe import ModalScoutEnsemble
+from sklearn.linear_model import LogisticRegression
+
+mse = ModalScoutEnsemble(base_estimator=LogisticRegression(), random_state=0)
+mse.fit(X, y)                      # fit
+mse.fit_predict(X, y)              # fit_predict
+mse.fit_transform(X, y)            # fit_transform
+mse.fit(X, y).transform(X)         # transform
+mse.fit(X, y).predict(X)           # predict
+mse.fit(X, y).predict_proba(X)     # predict_proba
+mse.fit(X, y).decision_function(X) # decision_function
+mse.fit(X, y).predict_regions(X)   # predict_regions
+mse.fit(X, y).score(X, y)          # score
+mse.fit(X, y).save("mse.joblib")   # save
+ModalScoutEnsemble.load("mse.joblib")
+</code></pre>
 <h2>Parameters</h2>
 <ul>
 <li><code>base_estimator</code> (<code>BaseEstimator</code>): model used to compute probabilities or

--- a/docs/regioninterpreter.html
+++ b/docs/regioninterpreter.html
@@ -18,6 +18,15 @@ from sheshe import RegionInterpreter
 ri = RegionInterpreter(feature_names=["sepal", "petal"])
 summary = ri.summarize(region)
 </code></pre>
+
+<h2>Usage examples</h2>
+<pre><code>
+from sheshe import RegionInterpreter
+
+ri = RegionInterpreter(feature_names=["sepal", "petal"])
+ri.summarize(region)       # summarize a single region
+ri.summarize([region])     # summarize a list of regions
+</code></pre>
 <h2>Parameters</h2>
 <ul>
 <li><code>feature_names</code> (<code>list[str]</code> or <code>None</code>, default <code>None</code>): names for each

--- a/docs/shushu.html
+++ b/docs/shushu.html
@@ -20,6 +20,24 @@ ss = ShuShu()
 ss.fit(X, y)
 labels = ss.predict(X)
 </code></pre>
+
+<h2>Usage examples</h2>
+<pre><code>
+from sheshe import ShuShu
+
+shu = ShuShu(random_state=0)
+shu.fit(X, y)                      # fit
+shu.fit_predict(X, y)              # fit_predict
+shu.fit_transform(X, y)            # fit_transform
+shu.fit(X, y).transform(X)         # transform
+shu.fit(X, y).predict(X)           # predict
+shu.fit(X, y).predict_proba(X)     # predict_proba
+shu.fit(X, y).decision_function(X) # decision_function
+shu.fit(X, y).predict_regions(X)   # predict_regions
+shu.fit(X, y).score(X, y)          # score
+shu.fit(X, y).save("shu.joblib")   # save
+ShuShu.load("shu.joblib")
+</code></pre>
 <h2>Parameters</h2>
 <ul>
 <li><code>clusterer_factory</code> (callable or <code>None</code>, default <code>None</code>): factory returning

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,4 +1,6 @@
-body {
+/* Scope all custom styles to the main content area so that the
+   default layout from the just-the-docs theme is not disrupted. */
+.main-content {
   font-family: "Helvetica Neue", Arial, sans-serif;
   line-height: 1.6;
   background-color: #fdfdfd;
@@ -8,23 +10,25 @@ body {
   padding: 2rem;
 }
 
-h1, h2, h3 {
+.main-content h1,
+.main-content h2,
+.main-content h3 {
   color: #003b5c;
 }
 
-pre {
+.main-content pre {
   background: #f0f0f0;
   padding: 1rem;
   overflow-x: auto;
   border-radius: 4px;
 }
 
-.doc-image {
+.main-content .doc-image {
   text-align: center;
   margin: 2rem 0;
 }
 
-.doc-image img {
+.main-content .doc-image img {
   max-width: 100%;
   height: auto;
   border: 1px solid #ddd;

--- a/docs/subspacescout.html
+++ b/docs/subspacescout.html
@@ -20,6 +20,15 @@ scout = SubspaceScout()
 scout.fit(X, y)
 subspaces = scout.results_
 </code></pre>
+
+<h2>Usage examples</h2>
+<pre><code>
+from sheshe import SubspaceScout
+
+scout = SubspaceScout(random_state=0)
+scout.fit(X, y)          # fit
+results = scout.results_ # access discovered subspaces
+</code></pre>
 <h2>Parameters</h2>
 <ul>
 <li><code>model_method</code> (<code>None</code> or <code>"lightgbm"</code> or <code>"ebm"</code>, default <code>None</code>): model


### PR DESCRIPTION
## Summary
- Scope custom CSS to main content to prevent text overlap on GitHub Pages
- Add comprehensive usage examples for each SheShe predictor

## Testing
- `pip install -e ".[dev]"` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b67642f1ac832c90b03ba420614573