### PR TITLE
docs: convert pages to HTML and expand predictor guides

### DIFF
--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -12,7 +12,9 @@ nav_order: 6
   <img src="images/cheche.png" alt="CheChe diagram">
 </figure>
 <p>Computes convex-hull frontiers for selected feature pairs and provides simple</p>
-<p>2D visualisations.</p>
+<p>2D visualisations. Useful for exploring decision boundaries or cluster shapes,</p>
+<p>it can subsample points via <code>mapping_level</code> and plot frontiers per class or</p>
+<p>for scalar score functions.</p>
 <h2>Example</h2>
 <pre><code>
 from sheshe import CheChe
@@ -34,6 +36,20 @@ che.fit(X, y).predict_regions(X)   # predict_regions
 che.fit(X, y).decision_function(X) # decision_function
 che.fit(X, y).save("che.joblib")   # save
 CheChe.load("che.joblib")
+</code></pre>
+<h2>Additional examples</h2>
+<pre><code>
+from sklearn.datasets import load_iris
+from sheshe import CheChe
+
+X, y = load_iris(return_X_y=True)
+ch = CheChe().fit(
+    X,
+    y,
+    feature_names=["sepal length", "sepal width", "petal length", "petal width"],
+    mapping_level=2,  # use every other sample
+)
+ch.plot_pairs(X, class_index=0)
 </code></pre>
 <h2>Parameters</h2>
 <ul>

--- a/docs/conventions.html
+++ b/docs/conventions.html
@@ -1,0 +1,106 @@
+---
+layout: default
+title: "Documentation Conventions"
+description: "Style and migration rules for SheShe docs"
+nav_order: 99
+---
+
+<link rel="stylesheet" href="style.css">
+
+<h1>Documentation Conventions</h1>
+
+<h2>Front matter</h2>
+<p>Each HTML page must begin with YAML front matter. Use the following template and adjust values as needed:</p>
+
+<pre><code>---
+layout: default
+title: "Page Title"
+description: "Short summary of the page"
+nav_order: 10
+---</code></pre>
+
+<h2>Headings</h2>
+<ul>
+  <li>Use a single <code>&lt;h1&gt;</code> that matches the page title.</li>
+  <li>Structure content with <code>&lt;h2&gt;</code> for sections and <code>&lt;h3&gt;</code> for subsections.</li>
+  <li>Do not skip heading levels.</li>
+</ul>
+
+<h2>Referencing the README</h2>
+<ul>
+  <li>Avoid duplicating long explanations that already exist in <code>README.md</code>.</li>
+  <li>When original content remains in the README, link to it using relative paths, e.g. <a href="../README.md#installation">Installation</a>.</li>
+  <li>Summaries may be included on Pages when useful, but keep the README as the canonical source for full instructions.</li>
+</ul>
+
+<h2>Links</h2>
+<ul>
+  <li>Use relative links with explicit file extensions, e.g. <a href="./quick_api.html">Quick API</a>.</li>
+  <li>Prefer <code>./</code> for same directory and <code>../</code> for parent directories.</li>
+  <li>Verify links before committing using a link checker such as <code>lychee</code>: <code>lychee docs/**/*.html</code>.</li>
+</ul>
+
+<h2>Migration checklist</h2>
+
+<h3>Highlights</h3>
+<ul>
+  <li>[ ] Create <code>docs/highlights.html</code>.</li>
+  <li>[ ] Add front matter and a single H1.</li>
+  <li>[ ] Summarise key benefits in bullets and link to predictor pages and Quick API.</li>
+</ul>
+
+<h3>Installation</h3>
+<ul>
+  <li>[ ] Create <code>docs/installation.html</code>.</li>
+  <li>[ ] Outline full install instructions including optional <code>numba</code> acceleration.</li>
+  <li>[ ] Reference requirements from README to avoid divergence.</li>
+</ul>
+
+<h3>Reproducibility</h3>
+<ul>
+  <li>[ ] Create <code>docs/reproducibility.html</code>.</li>
+  <li>[ ] Document OS, hardware, Python version and environment recreation steps.</li>
+</ul>
+
+<h3>Quick API</h3>
+<ul>
+  <li>[ ] Create <code>docs/quick_api.html</code>.</li>
+  <li>[ ] List public objects with brief descriptions.</li>
+</ul>
+
+<h3>Method matrix</h3>
+<ul>
+  <li>[ ] Create <code>docs/method_matrix.html</code>.</li>
+  <li>[ ] Translate table of implemented methods for each object.</li>
+</ul>
+
+<h3>Experiments &amp; Benchmarks</h3>
+<ul>
+  <li>[ ] Create <code>docs/experiments_benchmarks.html</code>.</li>
+  <li>[ ] Summarise available scripts and link to results in <code>benchmark/</code>.</li>
+</ul>
+
+<h3>Key parameters</h3>
+<ul>
+  <li>[ ] Create <code>docs/key_parameters.html</code>.</li>
+  <li>[ ] Describe tunable hyperparameters and their effects.</li>
+</ul>
+
+<h3>Performance tips</h3>
+<ul>
+  <li>[ ] Create <code>docs/performance_tips.html</code>.</li>
+  <li>[ ] Provide guidance for speeding up computations and scaling to high dimensions.</li>
+</ul>
+
+<h3>Limitations</h3>
+<ul>
+  <li>[ ] Create <code>docs/limitations.html</code>.</li>
+  <li>[ ] Clarify algorithmic and practical constraints.</li>
+</ul>
+
+<h3>Images</h3>
+<ul>
+  <li>[ ] Create <code>docs/images.html</code>.</li>
+  <li>[ ] Explain omission of binary assets and reference external repositories if needed.</li>
+</ul>
+

--- a/docs/highlights.html
+++ b/docs/highlights.html
@@ -1,0 +1,24 @@
+---
+layout: default
+title: "Highlights"
+description: "What you gain with SheShe"
+nav_order: 2
+---
+
+<link rel="stylesheet" href="style.css">
+
+<h1>Highlights</h1>
+
+<h2>Key Features</h2>
+<ul>
+  <li>Discover model-driven clusters via <a href="modalboundaryclustering.html">ModalBoundaryClustering</a>.</li>
+  <li>Works for classification and regression tasks.</li>
+  <li>Explore subspaces and build ensembles with <a href="subspacescout.html">SubspaceScout</a> and <a href="modalscoutensemble.html">ModalScoutEnsemble</a>.</li>
+  <li>Extract human-readable rules using <a href="regioninterpreter.html">RegionInterpreter</a>.</li>
+  <li>Search for local maxima with gradient-based <a href="shushu.html">ShuShu</a>.</li>
+  <li>Compute 2D decision frontiers through <a href="cheche.html">CheChe</a>.</li>
+  <li>Visualise pairwise and 3D surfaces with built-in plotting utilities.</li>
+</ul>
+
+<p>See the <a href="quick_api.html">Quick API</a> for a full reference of public objects.</p>
+

--- a/docs/modalboundaryclustering.html
+++ b/docs/modalboundaryclustering.html
@@ -12,7 +12,9 @@ nav_order: 1
   <img src="images/modalboundaryclustering.png" alt="ModalBoundaryClustering diagram">
 </figure>
 <p>Learns regions of high probability or predicted value by climbing local maxima of a</p>
-<p>base estimator.</p>
+<p>base estimator. Radial scans trace boundary surfaces around each mode and</p>
+<p>gradient ascent refines the centres, enabling both classification and regression</p>
+<p>workflows.</p>
 <h2>Example</h2>
 <pre><code>
 from sheshe import ModalBoundaryClustering
@@ -37,6 +39,27 @@ mbc.fit(X, y).predict_regions(X)   # predict_regions
 mbc.fit(X, y).score(X, y)          # score
 mbc.fit(X, y).save("mbc.joblib")   # save
 ModalBoundaryClustering.load("mbc.joblib")
+</code></pre>
+<h2>Additional examples</h2>
+<pre><code>
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+labels = ModalBoundaryClustering().fit_predict(X, y)
+
+from sklearn.datasets import load_diabetes
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestRegressor
+
+X, y = load_diabetes(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+reg = ModalBoundaryClustering(task="regression").fit(X_train, y_train)
+reg_retrained = ModalBoundaryClustering(
+    base_estimator=RandomForestRegressor(random_state=0),
+    task="regression",
+).fit(X_train, y_train)
 </code></pre>
 <h2>Parameters</h2>
 <ul>

--- a/docs/modalscoutensemble.html
+++ b/docs/modalscoutensemble.html
@@ -12,7 +12,9 @@ nav_order: 3
   <img src="images/modalscoutensemble.png" alt="ModalScoutEnsemble diagram">
 </figure>
 <p>Ensemble that applies <code>ModalBoundaryClustering</code> on the most promising</p>
-<p>subspaces discovered by <code>SubspaceScout</code>.</p>
+<p>subspaces discovered by <code>SubspaceScout</code>. Each submodel is weighted by scout</p>
+<p>score, cross-validation and feature importance, and the ensemble can delegate</p>
+<p>optimisation to <code>ShuShu</code> when <code>ensemble_method="shushu"</code>.</p>
 <h2>Example</h2>
 <pre><code>
 from sheshe import ModalScoutEnsemble
@@ -39,6 +41,27 @@ mse.fit(X, y).predict_regions(X)   # predict_regions
 mse.fit(X, y).score(X, y)          # score
 mse.fit(X, y).save("mse.joblib")   # save
 ModalScoutEnsemble.load("mse.joblib")
+</code></pre>
+<h2>Additional examples</h2>
+<pre><code>
+from sheshe import ModalScoutEnsemble
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+mse = ModalScoutEnsemble(
+    base_estimator=LogisticRegression(max_iter=200),
+    task="classification",
+    random_state=0,
+    scout_kwargs={"max_order": 2, "top_m": 4, "sample_size": None},
+    cv=2,
+    # ensemble_method="shushu" would use the ShuShu optimizer
+)
+mse.fit(X, y)
+print(mse.predict(X[:5]))
+print(mse.predict_proba(X[:5]))
 </code></pre>
 <h2>Parameters</h2>
 <ul>

--- a/docs/quick_api.html
+++ b/docs/quick_api.html
@@ -1,0 +1,77 @@
+---
+layout: default
+title: "Quick API"
+description: "Public objects exposed by the SheShe package"
+nav_order: 5
+---
+
+<link rel="stylesheet" href="style.css">
+
+<h1>Quick API</h1>
+
+<p>The following objects are available for import:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Submodule</th>
+      <th>Object</th>
+      <th>Import statement</th>
+      <th>Description</th>
+      <th>Docs</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>cheche</code></td>
+      <td><code>CheChe</code></td>
+      <td><code>from sheshe import CheChe</code></td>
+      <td>Compute 2D frontiers on selected feature pairs.</td>
+      <td><a href="cheche.html">cheche.html</a></td>
+    </tr>
+    <tr>
+      <td><code>sheshe</code></td>
+      <td><code>ClusterRegion</code></td>
+      <td><code>from sheshe import ClusterRegion</code></td>
+      <td>Dataclass describing a discovered region.</td>
+      <td>&mdash;</td>
+    </tr>
+    <tr>
+      <td><code>sheshe</code></td>
+      <td><code>ModalBoundaryClustering</code></td>
+      <td><code>from sheshe import ModalBoundaryClustering</code></td>
+      <td>Supervised clustering driven by model probabilities or predictions.</td>
+      <td><a href="modalboundaryclustering.html">modalboundaryclustering.html</a></td>
+    </tr>
+    <tr>
+      <td><code>modal_scout_ensemble</code></td>
+      <td><code>ModalScoutEnsemble</code></td>
+      <td><code>from sheshe import ModalScoutEnsemble</code></td>
+      <td>Explore subspaces with ensembles of scouts.</td>
+      <td><a href="modalscoutensemble.html">modalscoutensemble.html</a></td>
+    </tr>
+    <tr>
+      <td><code>region_interpretability</code></td>
+      <td><code>RegionInterpreter</code></td>
+      <td><code>from sheshe import RegionInterpreter</code></td>
+      <td>Turn <code>ClusterRegion</code> objects into human-readable rules.</td>
+      <td><a href="regioninterpreter.html">regioninterpreter.html</a></td>
+    </tr>
+    <tr>
+      <td><code>shushu</code></td>
+      <td><code>ShuShu</code></td>
+      <td><code>from sheshe import ShuShu</code></td>
+      <td>Gradient-based search for local maxima.</td>
+      <td><a href="shushu.html">shushu.html</a></td>
+    </tr>
+    <tr>
+      <td><code>subspace_scout</code></td>
+      <td><code>SubspaceScout</code></td>
+      <td><code>from sheshe import SubspaceScout</code></td>
+      <td>Explore subspaces to seed region discovery.</td>
+      <td><a href="subspacescout.html">subspacescout.html</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Detailed usage examples remain in the <a href="../README.md#quick-api">README</a>.</p>

--- a/docs/regioninterpreter.html
+++ b/docs/regioninterpreter.html
@@ -12,6 +12,9 @@ nav_order: 4
   <img src="images/regioninterpreter.png" alt="RegionInterpreter diagram">
 </figure>
 <p>Converts <code>ClusterRegion</code> objects into compact human‑readable rule sets.</p>
+<p>It summarises each region with axis‑aligned boxes, highlights informative</p>
+<p>projections and offers helpers like <code>pretty_print</code> for reporting. Optional</p>
+<p>LLM backends can turn the summaries into natural‑language descriptions.</p>
 <h2>Example</h2>
 <pre><code>
 from sheshe import RegionInterpreter
@@ -26,6 +29,18 @@ from sheshe import RegionInterpreter
 ri = RegionInterpreter(feature_names=["sepal", "petal"])
 ri.summarize(region)       # summarize a single region
 ri.summarize([region])     # summarize a list of regions
+</code></pre>
+<h2>Additional examples</h2>
+<pre><code>
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering, RegionInterpreter
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+sh = ModalBoundaryClustering().fit(X, y)
+cards = RegionInterpreter(feature_names=iris.feature_names).summarize(sh.regions_)
+RegionInterpreter.pretty_print(cards[:1])
 </code></pre>
 <h2>Parameters</h2>
 <ul>

--- a/docs/reproducibility.html
+++ b/docs/reproducibility.html
@@ -1,0 +1,62 @@
+---
+layout: default
+title: "Reproducibility"
+description: "Steps to recreate the SheShe environment"
+nav_order: 4
+---
+
+<link rel="stylesheet" href="style.css">
+
+<h1>Reproducibility</h1>
+
+<h2>Reference system</h2>
+<ul>
+  <li><strong>OS:</strong> Ubuntu 24.04.2 LTS</li>
+  <li><strong>CPU:</strong> Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz</li>
+  <li><strong>GPU:</strong> None</li>
+  <li><strong>Python:</strong> 3.12.10</li>
+ </ul>
+
+<h2>Environment setup</h2>
+<ol>
+  <li>Create and activate a virtual environment:
+<pre><code>python -m venv .venv
+source .venv/bin/activate</code></pre>
+  </li>
+  <li>Install development dependencies and run tests to verify:
+<pre><code>pip install -e ".[dev]"
+PYTHONPATH=src pytest -q</code></pre>
+  </li>
+</ol>
+
+<h2>Random seeds</h2>
+<p>All SheShe estimators accept a <code>random_state</code> argument to ensure deterministic results:</p>
+<pre><code>from sheshe import ModalBoundaryClustering
+clustering = ModalBoundaryClustering(random_state=0)</code></pre>
+<p>Set the same <code>random_state</code> across runs to reproduce experiments.</p>
+
+<h2>Export system information</h2>
+<p>Capture exact package versions and platform details for future reference:</p>
+<pre><code>python -m pip freeze > packages.txt
+python - <<'PY'
+import json, platform, sys
+info = {
+    "platform": platform.platform(),
+    "python": sys.version,
+}
+print(json.dumps(info, indent=2))
+PY
+</code></pre>
+
+<h2>How to report differences</h2>
+<p>If results differ from published benchmarks:</p>
+<ul>
+  <li>Share the generated <code>packages.txt</code> and platform JSON.</li>
+  <li>Describe the dataset and parameters used, including <code>random_state</code> values.</li>
+  <li>Open an issue with logs and reproduction steps.</li>
+</ul>
+
+<h2>TODO</h2>
+<ul>
+  <li>Specify recommended RAM capacity.</li>
+</ul>

--- a/docs/shushu.html
+++ b/docs/shushu.html
@@ -12,7 +12,9 @@ nav_order: 5
   <img src="images/shushu.png" alt="ShuShu diagram">
 </figure>
 <p>Gradient-based optimiser that searches for local maxima of a scalar score or</p>
-<p>class probabilities.</p>
+<p>class probabilities. Runs one optimisation per class when labels are given and</p>
+<p>can also operate on arbitrary user-defined score functions, returning cluster</p>
+<p>centroids for each discovered mode.</p>
 <h2>Example</h2>
 <pre><code>
 from sheshe import ShuShu
@@ -37,6 +39,22 @@ shu.fit(X, y).predict_regions(X)   # predict_regions
 shu.fit(X, y).score(X, y)          # score
 shu.fit(X, y).save("shu.joblib")   # save
 ShuShu.load("shu.joblib")
+</code></pre>
+<h2>Additional examples</h2>
+<pre><code>
+from sklearn.datasets import load_iris
+from sheshe import ShuShu
+
+X, y = load_iris(return_X_y=True)
+sh = ShuShu(random_state=0).fit(X, y)
+print(sh.summary_tables()[0][["class_label", "n_clusters"]])
+
+import numpy as np
+def paraboloid(Z):
+    return -np.linalg.norm(Z - 1.0, axis=1)
+
+sc = ShuShu(random_state=0).fit(np.random.rand(100, 2), score_fn=paraboloid)
+print(sc.centroids_)
 </code></pre>
 <h2>Parameters</h2>
 <ul>

--- a/docs/subspacescout.html
+++ b/docs/subspacescout.html
@@ -12,7 +12,9 @@ nav_order: 2
   <img src="images/subspacescout.png" alt="SubspaceScout diagram">
 </figure>
 <p>Identifies informative feature subsets so that <code>ModalBoundaryClustering</code> can</p>
-<p>run only where it matters in high-dimensional spaces.</p>
+<p>run only where it matters in high-dimensional spaces. Uses mutual information or</p>
+<p>optional model-based scorers to rank interactions and employs beam search to</p>
+<p>enumerate promising subspaces.</p>
 <h2>Example</h2>
 <pre><code>
 from sheshe import SubspaceScout
@@ -28,6 +30,27 @@ from sheshe import SubspaceScout
 scout = SubspaceScout(random_state=0)
 scout.fit(X, y)          # fit
 results = scout.results_ # access discovered subspaces
+</code></pre>
+<h2>Additional examples</h2>
+<pre><code>
+from sheshe import SubspaceScout
+
+scout = SubspaceScout(
+    # model_method='lightgbm',  # default uses mutual information
+    max_order=4,
+    top_m=50,
+    base_pairs_limit=12,
+    beam_width=10,
+    extend_candidate_pool=16,
+    branch_per_parent=4,
+    marginal_gain_min=1e-3,
+    max_eval_per_order=150,
+    sample_size=4096,
+    time_budget_s=None,
+    task='classification',
+    random_state=0,
+)
+subspaces = scout.fit(X, y)
 </code></pre>
 <h2>Parameters</h2>
 <ul>


### PR DESCRIPTION
## Summary
- convert highlights, reproducibility, quick API and conventions docs from Markdown to HTML with Jekyll front matter
- expand predictor guides with detailed explanations and README-derived code examples

## Testing
- `PYTHONPATH=src pytest tests/test_basic.py::test_import_and_fit -q`
- `lychee docs/**/*.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b67d0f004c832c86a174cac1c0e315