### PR TITLE
docs: add text-based graph examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,16 @@ surface.
 - Human-readable rule extraction through `RegionInterpreter`.
 - Built-in plotting utilities for pairwise and 3D visualisations.
 
-*Feature overview figure omitted (binary assets are not allowed).* 
+*Feature overview figure omitted (binary assets are not allowed).* The text-based chart below offers a rough illustration of a two-dimensional decision surface:
+
+```
+y
+^    o
+|   o o
+|  o   o
+| o     o
++--------------> x
+```
 
 ---
 
@@ -889,7 +898,16 @@ python experiments/paper_experiments.py --runs 5
 
 ## Images
 
-Figures have been intentionally omitted because this repository does not permit storing binary assets.
+Figures have been intentionally omitted because this repository does not permit storing binary assets. The following text-based chart demonstrates an example 2D scatter plot:
+
+```
+y
+^    o
+|   o o
+|  o   o
+| o     o
++--------------> x
+```
 
 ---
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -16,7 +16,16 @@ traza los clúesteres directamente sobre la superficie de decisión.
 - Extracción de reglas interpretables a través de `RegionInterpreter`.
 - Utilidades de graficado integradas para visualizaciones 2D y 3D.
 
-*Figura de resumen de características omitida (no se permiten archivos binarios).* 
+*Figura de resumen de características omitida (no se permiten archivos binarios).* La siguiente gráfica en texto ilustra de manera aproximada una superficie de decisión bidimensional:
+
+```
+y
+^    o
+|   o o
+|  o   o
+| o     o
++--------------> x
+```
 
 ---
 
@@ -757,7 +766,16 @@ python experiments/paper_experiments.py
 
 ## Imágenes
 
-Las figuras se han omitido deliberadamente porque este repositorio no permite almacenar archivos binarios.
+Las figuras se han omitido deliberadamente porque este repositorio no permite almacenar archivos binarios. La siguiente gráfica basada en texto muestra un ejemplo de dispersión 2D:
+
+```
+y
+^    o
+|   o o
+|  o   o
+| o     o
++--------------> x
+```
 
 ---
 

--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -9,7 +9,15 @@ nav_order: 6
 <h1>CheChe</h1>
 
 <figure class="doc-image">
-  <img src="images/cheche.png" alt="CheChe diagram">
+  <pre>
+y
+^    o
+|   o o
+|  o   o
+| o     o
++--------------> x
+  </pre>
+  <figcaption>Example text-based plot.</figcaption>
 </figure>
 <p>Computes convex-hull frontiers for selected feature pairs and provides simple</p>
 <p>2D visualisations. Useful for exploring decision boundaries or cluster shapes,</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,15 @@ has_children: true
 <h1>SheShe</h1>
 
 <figure class="doc-image">
-  <img src="images/overview.png" alt="SheShe overview diagram">
+  <pre>
+y
+^    o
+|   o o
+|  o   o
+| o     o
++--------------> x
+  </pre>
+  <figcaption>Example text-based plot.</figcaption>
 </figure>
 
 <p>Smart High-dimensional Edge Segmentation &amp; Hyperboundary Explorer</p>

--- a/docs/modalboundaryclustering.html
+++ b/docs/modalboundaryclustering.html
@@ -9,7 +9,15 @@ nav_order: 1
 <h1>ModalBoundaryClustering</h1>
 
 <figure class="doc-image">
-  <img src="images/modalboundaryclustering.png" alt="ModalBoundaryClustering diagram">
+  <pre>
+y
+^    o
+|   o o
+|  o   o
+| o     o
++--------------> x
+  </pre>
+  <figcaption>Example text-based plot.</figcaption>
 </figure>
 <p>Learns regions of high probability or predicted value by climbing local maxima of a</p>
 <p>base estimator. Radial scans trace boundary surfaces around each mode and</p>

--- a/docs/modalscoutensemble.html
+++ b/docs/modalscoutensemble.html
@@ -9,7 +9,15 @@ nav_order: 3
 <h1>ModalScoutEnsemble</h1>
 
 <figure class="doc-image">
-  <img src="images/modalscoutensemble.png" alt="ModalScoutEnsemble diagram">
+  <pre>
+y
+^    o
+|   o o
+|  o   o
+| o     o
++--------------> x
+  </pre>
+  <figcaption>Example text-based plot.</figcaption>
 </figure>
 <p>Ensemble that applies <code>ModalBoundaryClustering</code> on the most promising</p>
 <p>subspaces discovered by <code>SubspaceScout</code>. Each submodel is weighted by scout</p>

--- a/docs/regioninterpreter.html
+++ b/docs/regioninterpreter.html
@@ -9,7 +9,15 @@ nav_order: 4
 <h1>RegionInterpreter</h1>
 
 <figure class="doc-image">
-  <img src="images/regioninterpreter.png" alt="RegionInterpreter diagram">
+  <pre>
+y
+^    o
+|   o o
+|  o   o
+| o     o
++--------------> x
+  </pre>
+  <figcaption>Example text-based plot.</figcaption>
 </figure>
 <p>Converts <code>ClusterRegion</code> objects into compact human‑readable rule sets.</p>
 <p>It summarises each region with axis‑aligned boxes, highlights informative</p>

--- a/docs/shushu.html
+++ b/docs/shushu.html
@@ -9,7 +9,15 @@ nav_order: 5
 <h1>ShuShu</h1>
 
 <figure class="doc-image">
-  <img src="images/shushu.png" alt="ShuShu diagram">
+  <pre>
+y
+^    o
+|   o o
+|  o   o
+| o     o
++--------------> x
+  </pre>
+  <figcaption>Example text-based plot.</figcaption>
 </figure>
 <p>Gradient-based optimiser that searches for local maxima of a scalar score or</p>
 <p>class probabilities. Runs one optimisation per class when labels are given and</p>

--- a/docs/subspacescout.html
+++ b/docs/subspacescout.html
@@ -9,7 +9,15 @@ nav_order: 2
 <h1>SubspaceScout</h1>
 
 <figure class="doc-image">
-  <img src="images/subspacescout.png" alt="SubspaceScout diagram">
+  <pre>
+y
+^    o
+|   o o
+|  o   o
+| o     o
++--------------> x
+  </pre>
+  <figcaption>Example text-based plot.</figcaption>
 </figure>
 <p>Identifies informative feature subsets so that <code>ModalBoundaryClustering</code> can</p>
 <p>run only where it matters in high-dimensional spaces. Uses mutual information or</p>


### PR DESCRIPTION
## Summary
- replace missing diagrams with text-based chart examples in docs and READMEs
- ensure all documentation sections include illustrative graph snippets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6912d56b8832caa47a2a1da4e6014