### PR TITLE
docs: add plotting examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,19 @@ surface.
 - Human-readable rule extraction through `RegionInterpreter`.
 - Built-in plotting utilities for pairwise and 3D visualisations.
 
-*Feature overview figure omitted (binary assets are not allowed).* 
+*Feature overview figure omitted (binary assets are not allowed).*
+Generate an equivalent plot on your machine:
+
+```python
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+sh = ModalBoundaryClustering().fit(X, y)
+sh.plot_pairs(X, y, max_pairs=1)
+plt.show()
+```
 
 ---
 
@@ -77,6 +89,18 @@ The library exposes seven main objects:
 - `CheChe` – compute 2D frontiers on selected feature pairs
 
 Figures illustrating these objects are omitted because binary assets are not allowed in this repository.
+You can visualise a 3D decision surface with:
+
+```python
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+sh = ModalBoundaryClustering().fit(X, y)
+sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0])
+plt.show()
+```
 
 ```python
 from sheshe import (

--- a/README_ES.md
+++ b/README_ES.md
@@ -16,7 +16,19 @@ traza los clúesteres directamente sobre la superficie de decisión.
 - Extracción de reglas interpretables a través de `RegionInterpreter`.
 - Utilidades de graficado integradas para visualizaciones 2D y 3D.
 
-*Figura de resumen de características omitida (no se permiten archivos binarios).* 
+*Figura de resumen de características omitida (no se permiten archivos binarios).*
+Genera un gráfico equivalente en tu entorno:
+
+```python
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+sh = ModalBoundaryClustering().fit(X, y)
+sh.plot_pairs(X, y, max_pairs=1)
+plt.show()
+```
 
 ---
 
@@ -54,6 +66,18 @@ La librería expone siete objetos principales:
 - `CheChe` – calcula fronteras 2D sobre pares de características seleccionados
 
 Las figuras ilustrativas de estos objetos se omiten porque el repositorio no admite archivos binarios.
+Puedes visualizar una superficie de decisión en 3D con:
+
+```python
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+sh = ModalBoundaryClustering().fit(X, y)
+sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0])
+plt.show()
+```
 
 ```python
 from sheshe import (

--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -8,9 +8,16 @@ nav_order: 6
 
 <h1>CheChe</h1>
 
-<figure class="doc-image">
-  <img src="images/cheche.png" alt="CheChe diagram">
-</figure>
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import CheChe
+
+X, y = load_iris(return_X_y=True)
+che = CheChe().fit(X, y)
+che.plot_pairs(X, y, max_pairs=1)
+plt.show()
+</code></pre>
 <p>Computes convex-hull frontiers for selected feature pairs and provides simple</p>
 <p>2D visualisations. Useful for exploring decision boundaries or cluster shapes,</p>
 <p>it can subsample points via <code>mapping_level</code> and plot frontiers per class or</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,9 +9,16 @@ has_children: true
 
 <h1>SheShe</h1>
 
-<figure class="doc-image">
-  <img src="images/overview.png" alt="SheShe overview diagram">
-</figure>
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+sh = ModalBoundaryClustering().fit(X, y)
+sh.plot_pairs(X, y, max_pairs=1)
+plt.show()
+</code></pre>
 
 <p>Smart High-dimensional Edge Segmentation &amp; Hyperboundary Explorer</p>
 

--- a/docs/modalboundaryclustering.html
+++ b/docs/modalboundaryclustering.html
@@ -8,9 +8,16 @@ nav_order: 1
 
 <h1>ModalBoundaryClustering</h1>
 
-<figure class="doc-image">
-  <img src="images/modalboundaryclustering.png" alt="ModalBoundaryClustering diagram">
-</figure>
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+sh = ModalBoundaryClustering().fit(X, y)
+sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0])
+plt.show()
+</code></pre>
 <p>Learns regions of high probability or predicted value by climbing local maxima of a</p>
 <p>base estimator. Radial scans trace boundary surfaces around each mode and</p>
 <p>gradient ascent refines the centres, enabling both classification and regression</p>

--- a/docs/modalscoutensemble.html
+++ b/docs/modalscoutensemble.html
@@ -8,9 +8,16 @@ nav_order: 3
 
 <h1>ModalScoutEnsemble</h1>
 
-<figure class="doc-image">
-  <img src="images/modalscoutensemble.png" alt="ModalScoutEnsemble diagram">
-</figure>
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ModalScoutEnsemble
+
+X, y = load_iris(return_X_y=True)
+mse = ModalScoutEnsemble().fit(X, y)
+mse.plot_pairs(X, y, max_pairs=1)
+plt.show()
+</code></pre>
 <p>Ensemble that applies <code>ModalBoundaryClustering</code> on the most promising</p>
 <p>subspaces discovered by <code>SubspaceScout</code>. Each submodel is weighted by scout</p>
 <p>score, cross-validation and feature importance, and the ensemble can delegate</p>

--- a/docs/regioninterpreter.html
+++ b/docs/regioninterpreter.html
@@ -8,9 +8,18 @@ nav_order: 4
 
 <h1>RegionInterpreter</h1>
 
-<figure class="doc-image">
-  <img src="images/regioninterpreter.png" alt="RegionInterpreter diagram">
-</figure>
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering, RegionInterpreter
+
+iris = load_iris()
+X, y = iris.data, iris.target
+sh = ModalBoundaryClustering().fit(X, y)
+cards = RegionInterpreter(feature_names=iris.feature_names).summarize(sh.regions_)
+sh.plot_pairs(X, y, max_pairs=1)
+plt.show()
+</code></pre>
 <p>Converts <code>ClusterRegion</code> objects into compact human‑readable rule sets.</p>
 <p>It summarises each region with axis‑aligned boxes, highlights informative</p>
 <p>projections and offers helpers like <code>pretty_print</code> for reporting. Optional</p>

--- a/docs/shushu.html
+++ b/docs/shushu.html
@@ -8,9 +8,16 @@ nav_order: 5
 
 <h1>ShuShu</h1>
 
-<figure class="doc-image">
-  <img src="images/shushu.png" alt="ShuShu diagram">
-</figure>
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ShuShu
+
+X, y = load_iris(return_X_y=True)
+sh = ShuShu().fit(X, y)
+sh.plot_pairs(X, y, max_pairs=1)
+plt.show()
+</code></pre>
 <p>Gradient-based optimiser that searches for local maxima of a scalar score or</p>
 <p>class probabilities. Runs one optimisation per class when labels are given and</p>
 <p>can also operate on arbitrary user-defined score functions, returning cluster</p>

--- a/docs/subspacescout.html
+++ b/docs/subspacescout.html
@@ -8,9 +8,17 @@ nav_order: 2
 
 <h1>SubspaceScout</h1>
 
-<figure class="doc-image">
-  <img src="images/subspacescout.png" alt="SubspaceScout diagram">
-</figure>
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import SubspaceScout, ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+scout = SubspaceScout().fit(X, y)
+pair = scout.results_[0]["features"]
+ModalBoundaryClustering().fit(X, y).plot_pairs(X, y, pairs=[pair])
+plt.show()
+</code></pre>
 <p>Identifies informative feature subsets so that <code>ModalBoundaryClustering</code> can</p>
 <p>run only where it matters in high-dimensional spaces. Uses mutual information or</p>
 <p>optional model-based scorers to rank interactions and employs beam search to</p>


### PR DESCRIPTION
## Summary
- Replace missing figure placeholders in README and docs with runnable plotting snippets.
- Add example code for pairwise and 3D plots in English and Spanish documentation.

## Testing
- `pytest -q`
- `PYTHONPATH=src pytest tests/test_basic.py::test_import_and_fit -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6912d56b8832caa47a2a1da4e6014