### PR TITLE
docs: add installation guide

### DIFF
--- a/docs/conventions.html
+++ b/docs/conventions.html
@@ -51,9 +51,9 @@ nav_order: 10
 
 <h3>Installation</h3>
 <ul>
-  <li>[ ] Create <code>docs/installation.html</code>.</li>
-  <li>[ ] Outline full install instructions including optional <code>numba</code> acceleration.</li>
-  <li>[ ] Reference requirements from README to avoid divergence.</li>
+  <li>[x] Create <a href="./installation.html">installation.html</a>.</li>
+  <li>[x] Outline full install instructions including optional <code>numba</code> acceleration.</li>
+  <li>[x] Reference requirements from README to avoid divergence.</li>
 </ul>
 
 <h3>Reproducibility</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,6 +24,7 @@ has_children: true
 <pre><code>pip install sheshe
 PYTHONPATH=src pytest tests/test_basic.py::test_import_and_fit -q
 </code></pre>
+<p>See <a href="./installation.html">Installation</a> for full instructions.</p>
 
 <h2>Predictors</h2>
 

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -1,0 +1,28 @@
+---
+layout: default
+title: "Installation"
+description: "Requirements and setup instructions for SheShe"
+nav_order: 3
+---
+
+<link rel="stylesheet" href="style.css">
+
+<h1>Installation</h1>
+
+<h2>Requirements</h2>
+<p>SheShe requires <strong>Python &gt;=3.9</strong>. It is best to work inside a virtual environment. Base dependencies include <code>numpy</code>, <code>pandas</code>, <code>scikit-learn&gt;=1.1</code>, and <code>matplotlib</code>. See the <a href="../README.md#installation">README</a> for reference.</p>
+
+<h2>Install from PyPI</h2>
+<p>Install the latest release from PyPI:</p>
+<pre><code>pip install sheshe
+</code></pre>
+<p>Optional acceleration is available via <a href="https://numba.pydata.org/">numba</a>:</p>
+<pre><code>pip install "sheshe[numba]"
+</code></pre>
+
+<h2>Development environment</h2>
+<p>To hack on SheShe, install in editable mode with test dependencies and run the test suite:</p>
+<pre><code>pip install -e ".[dev]"
+PYTHONPATH=src pytest -q
+</code></pre>
+


### PR DESCRIPTION
## Summary
- add installation.html with Python requirements, PyPI install, optional numba acceleration, and development setup
- link installation guide from index and conventions

## Testing
- `pytest -q`
- `lychee docs/**/*.html` *(fails: command not found; cargo install unable to download config.json, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b69138b1c0832cb0991ef043150fd4