### PR TITLE
style: refresh docs color palette

### DIFF
--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -16,7 +16,7 @@ nav_order: 6
 <p>it can subsample points via <code>mapping_level</code> and plot frontiers per class or</p>
 <p>for scalar score functions.</p>
 <h2>Example</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import CheChe
 cc = CheChe()
 cc.fit(X, y)
@@ -24,7 +24,7 @@ cc.plot_pairs(X)
 </code></pre>
 
 <h2>Usage examples</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import CheChe
 
 che = CheChe(random_state=0)
@@ -38,7 +38,7 @@ che.fit(X, y).save("che.joblib")   # save
 CheChe.load("che.joblib")
 </code></pre>
 <h2>Additional examples</h2>
-<pre><code>
+<pre><code class="language-python">
 from sklearn.datasets import load_iris
 from sheshe import CheChe
 

--- a/docs/conventions.html
+++ b/docs/conventions.html
@@ -12,7 +12,7 @@ nav_order: 99
 <h2>Front matter</h2>
 <p>Each HTML page must begin with YAML front matter. Use the following template and adjust values as needed:</p>
 
-<pre><code>---
+<pre><code class="language-python">---
 layout: default
 title: "Page Title"
 description: "Short summary of the page"

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@ has_children: true
 
 <p>Install the library and run the basic tests:</p>
 
-<pre><code>pip install sheshe
+<pre><code class="language-python">pip install sheshe
 PYTHONPATH=src pytest tests/test_basic.py::test_import_and_fit -q
 </code></pre>
 
@@ -42,7 +42,7 @@ PYTHONPATH=src pytest tests/test_basic.py::test_import_and_fit -q
 
 <p>Improvements are welcome! Fork the repository, install development dependencies, and run the tests:</p>
 
-<pre><code>pip install -e ".[dev]"
+<pre><code class="language-python">pip install -e ".[dev]"
 PYTHONPATH=src pytest -q
 </code></pre>
 

--- a/docs/modalboundaryclustering.html
+++ b/docs/modalboundaryclustering.html
@@ -16,7 +16,7 @@ nav_order: 1
 <p>gradient ascent refines the centres, enabling both classification and regression</p>
 <p>workflows.</p>
 <h2>Example</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import ModalBoundaryClustering
 mbc = ModalBoundaryClustering()
 mbc.fit(X, y)
@@ -24,7 +24,7 @@ labels = mbc.predict(X)
 </code></pre>
 
 <h2>Usage examples</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import ModalBoundaryClustering
 
 mbc = ModalBoundaryClustering(random_state=0)
@@ -41,7 +41,7 @@ mbc.fit(X, y).save("mbc.joblib")   # save
 ModalBoundaryClustering.load("mbc.joblib")
 </code></pre>
 <h2>Additional examples</h2>
-<pre><code>
+<pre><code class="language-python">
 from sklearn.datasets import load_iris
 from sheshe import ModalBoundaryClustering
 

--- a/docs/modalscoutensemble.html
+++ b/docs/modalscoutensemble.html
@@ -16,7 +16,7 @@ nav_order: 3
 <p>score, cross-validation and feature importance, and the ensemble can delegate</p>
 <p>optimisation to <code>ShuShu</code> when <code>ensemble_method="shushu"</code>.</p>
 <h2>Example</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import ModalScoutEnsemble
 from sklearn.linear_model import LogisticRegression
 mse = ModalScoutEnsemble(base_estimator=LogisticRegression())
@@ -25,7 +25,7 @@ labels = mse.predict(X)
 </code></pre>
 
 <h2>Usage examples</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import ModalScoutEnsemble
 from sklearn.linear_model import LogisticRegression
 
@@ -43,7 +43,7 @@ mse.fit(X, y).save("mse.joblib")   # save
 ModalScoutEnsemble.load("mse.joblib")
 </code></pre>
 <h2>Additional examples</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import ModalScoutEnsemble
 from sklearn.datasets import load_iris
 from sklearn.linear_model import LogisticRegression

--- a/docs/regioninterpreter.html
+++ b/docs/regioninterpreter.html
@@ -16,14 +16,14 @@ nav_order: 4
 <p>projections and offers helpers like <code>pretty_print</code> for reporting. Optional</p>
 <p>LLM backends can turn the summaries into natural‑language descriptions.</p>
 <h2>Example</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import RegionInterpreter
 ri = RegionInterpreter(feature_names=["sepal", "petal"])
 summary = ri.summarize(region)
 </code></pre>
 
 <h2>Usage examples</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import RegionInterpreter
 
 ri = RegionInterpreter(feature_names=["sepal", "petal"])
@@ -31,7 +31,7 @@ ri.summarize(region)       # summarize a single region
 ri.summarize([region])     # summarize a list of regions
 </code></pre>
 <h2>Additional examples</h2>
-<pre><code>
+<pre><code class="language-python">
 from sklearn.datasets import load_iris
 from sheshe import ModalBoundaryClustering, RegionInterpreter
 

--- a/docs/reproducibility.html
+++ b/docs/reproducibility.html
@@ -20,24 +20,24 @@ nav_order: 4
 <h2>Environment setup</h2>
 <ol>
   <li>Create and activate a virtual environment:
-<pre><code>python -m venv .venv
+<pre><code class="language-python">python -m venv .venv
 source .venv/bin/activate</code></pre>
   </li>
   <li>Install development dependencies and run tests to verify:
-<pre><code>pip install -e ".[dev]"
+<pre><code class="language-python">pip install -e ".[dev]"
 PYTHONPATH=src pytest -q</code></pre>
   </li>
 </ol>
 
 <h2>Random seeds</h2>
 <p>All SheShe estimators accept a <code>random_state</code> argument to ensure deterministic results:</p>
-<pre><code>from sheshe import ModalBoundaryClustering
+<pre><code class="language-python">from sheshe import ModalBoundaryClustering
 clustering = ModalBoundaryClustering(random_state=0)</code></pre>
 <p>Set the same <code>random_state</code> across runs to reproduce experiments.</p>
 
 <h2>Export system information</h2>
 <p>Capture exact package versions and platform details for future reference:</p>
-<pre><code>python -m pip freeze > packages.txt
+<pre><code class="language-python">python -m pip freeze > packages.txt
 python - <<'PY'
 import json, platform, sys
 info = {

--- a/docs/shushu.html
+++ b/docs/shushu.html
@@ -16,7 +16,7 @@ nav_order: 5
 <p>can also operate on arbitrary user-defined score functions, returning cluster</p>
 <p>centroids for each discovered mode.</p>
 <h2>Example</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import ShuShu
 ss = ShuShu()
 ss.fit(X, y)
@@ -24,7 +24,7 @@ labels = ss.predict(X)
 </code></pre>
 
 <h2>Usage examples</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import ShuShu
 
 shu = ShuShu(random_state=0)
@@ -41,7 +41,7 @@ shu.fit(X, y).save("shu.joblib")   # save
 ShuShu.load("shu.joblib")
 </code></pre>
 <h2>Additional examples</h2>
-<pre><code>
+<pre><code class="language-python">
 from sklearn.datasets import load_iris
 from sheshe import ShuShu
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,10 +1,19 @@
 /* Scope all custom styles to the main content area so that the
    default layout from the just-the-docs theme is not disrupted. */
+:root {
+  --primary-color: #1e6091;
+  --accent-color: #ff6b6b;
+  --text-color: #2b2d42;
+  --background-color: #f8fafc;
+  --code-bg: #e2e8f0;
+  --border-color: #cbd5e1;
+}
+
 .main-content {
   font-family: "Helvetica Neue", Arial, sans-serif;
   line-height: 1.6;
-  background-color: #fdfdfd;
-  color: #333;
+  background-color: var(--background-color);
+  color: var(--text-color);
   max-width: 900px;
   margin: 0 auto;
   padding: 2rem;
@@ -13,13 +22,35 @@
 .main-content h1,
 .main-content h2,
 .main-content h3 {
-  color: #003b5c;
+  color: var(--primary-color);
+}
+
+.main-content a {
+  color: var(--accent-color);
+}
+
+.main-content a:hover {
+  color: var(--primary-color);
+}
+
+.main-content code {
+  font-family: "Source Code Pro", Menlo, monospace;
+  background: var(--code-bg);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+}
+
+.main-content pre code {
+  background: none;
+  padding: 0;
+  display: block;
 }
 
 .main-content pre {
-  background: #f0f0f0;
+  background: var(--code-bg);
   padding: 1rem;
   overflow-x: auto;
+  border-left: 4px solid var(--primary-color);
   border-radius: 4px;
 }
 
@@ -31,7 +62,7 @@
 .main-content .doc-image img {
   max-width: 100%;
   height: auto;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }

--- a/docs/subspacescout.html
+++ b/docs/subspacescout.html
@@ -16,7 +16,7 @@ nav_order: 2
 <p>optional model-based scorers to rank interactions and employs beam search to</p>
 <p>enumerate promising subspaces.</p>
 <h2>Example</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import SubspaceScout
 scout = SubspaceScout()
 scout.fit(X, y)
@@ -24,7 +24,7 @@ subspaces = scout.results_
 </code></pre>
 
 <h2>Usage examples</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import SubspaceScout
 
 scout = SubspaceScout(random_state=0)
@@ -32,7 +32,7 @@ scout.fit(X, y)          # fit
 results = scout.results_ # access discovered subspaces
 </code></pre>
 <h2>Additional examples</h2>
-<pre><code>
+<pre><code class="language-python">
 from sheshe import SubspaceScout
 
 scout = SubspaceScout(


### PR DESCRIPTION
## Summary
- brighten docs with primary and accent color variables
- update code block and image styles for a cleaner look
- mark examples as Python code blocks for syntax-aware styling

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b690f723cc832ca708eb32dc1aed14