### PR TITLE
docs: add 3d visualization guide

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,6 +36,7 @@ PYTHONPATH=src pytest tests/test_basic.py::test_import_and_fit -q
   <li><a href="regioninterpreter.html">RegionInterpreter</a></li>
   <li><a href="shushu.html">ShuShu</a></li>
   <li><a href="cheche.html">CheChe</a></li>
+  <li><a href="visualization_3d.html">3D Visualization</a></li>
 </ul>
 
 <h2>Contribute</h2>

--- a/docs/modalboundaryclustering.html
+++ b/docs/modalboundaryclustering.html
@@ -203,7 +203,5 @@ reg_retrained = ModalBoundaryClustering(
 <li><code>plot_pairs(X, y=None, max_pairs=None)</code> – 2D decision plots for feature
  pairs.
 </li>
-<li><code>plot_pair_3d(X, pair, class_label=None, grid_res=50, alpha_surface=0.6,
- engine="matplotlib")</code> – render a 3D surface for a feature pair.
-</li>
+<li><code><a href="visualization_3d.html">plot_pair_3d(X, pair, class_label=None, grid_res=50, alpha_surface=0.6, engine="matplotlib")</a></code> – render a 3D surface for a feature pair.</li>
 </ul>

--- a/docs/visualization_3d.html
+++ b/docs/visualization_3d.html
@@ -1,0 +1,42 @@
+---
+layout: default
+title: 3D Visualization
+parent: SheShe
+nav_order: 7
+---
+<link rel="stylesheet" href="style.css">
+
+<h1>3D Visualization</h1>
+
+<p>Use <code>plot_pair_3d</code> to render a probability or regression surface
+for any pair of features.</p>
+
+<h2>Example</h2>
+<pre><code>from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+mbc = ModalBoundaryClustering(random_state=0).fit(X, y)
+
+# basic surface for the first two features
+mbc.plot_pair_3d(X, pair=(0, 1), class_label=mbc.classes_[0])
+</code></pre>
+
+<h2>Parameters</h2>
+<ul>
+  <li><code>pair</code> (<code>tuple[int, int]</code>): indices of the two features to visualise.</li>
+  <li><code>class_label</code> (<code>int</code> or <code>str</code>, optional): class whose
+      probability surface is drawn. Required for classification.</li>
+  <li><code>grid_res</code> (<code>int</code>, default <code>50</code>): resolution of the 3D grid.</li>
+</ul>
+
+<h2>Plotly example</h2>
+<pre><code>fig = mbc.plot_pair_3d(
+    X,
+    pair=(0, 1),
+    class_label=mbc.classes_[0],
+    grid_res=75,
+    engine="plotly",
+)
+fig.show()
+</code></pre>


### PR DESCRIPTION
## Summary
- document `plot_pair_3d` in new 3D visualization guide
- link the new guide from index and ModalBoundaryClustering docs

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6913b5168832ca6bd898be1e0fae1