### PR TITLE
docs: add author about section

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,6 +917,12 @@ Figures have been intentionally omitted because this repository does not permit 
 
 ---
 
+## About
+
+SheShe is authored by José Carlos Del Valle. Connect with him on [LinkedIn](https://www.linkedin.com/in/jose-carlos-del-valle/) or explore his [portfolio](https://jcval94.github.io/Portfolio/).
+
+---
+
 ## Contribute
 
 Improvements are welcome. To propose changes:

--- a/README_ES.md
+++ b/README_ES.md
@@ -785,6 +785,12 @@ Las figuras se han omitido deliberadamente porque este repositorio no permite al
 
 ---
 
+## Sobre el autor
+
+SheShe es desarrollado por José Carlos Del Valle. Encuéntralo en [LinkedIn](https://www.linkedin.com/in/jose-carlos-del-valle/) o visita su [portafolio](https://jcval94.github.io/Portfolio/).
+
+---
+
 ## Contribuir
 
 Las mejoras son bienvenidas. Para proponer cambios:

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,6 +49,10 @@ PYTHONPATH=src pytest tests/test_basic.py::test_import_and_fit -q
   <li><a href="visualization_3d.html">3D Visualization</a></li>
 </ul>
 
+<h2>About</h2>
+
+<p>SheShe is developed by José Carlos Del Valle. Connect on <a href="https://www.linkedin.com/in/jose-carlos-del-valle/">LinkedIn</a> or explore his <a href="https://jcval94.github.io/Portfolio/">portfolio</a>.</p>
+
 <h2>Contribute</h2>
 
 <p>Improvements are welcome! Fork the repository, install development dependencies, and run the tests:</p>


### PR DESCRIPTION
## Summary
- highlight Jose Carlos Del Valle as project author in English and Spanish READMEs
- introduce "About" section to docs homepage with author links

## Testing
- `PYTHONPATH=src pytest -q`
- `lychee docs/**/*.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b710b99ae8832c815d885fbe436849