### PR TITLE
Document key hyperparameters and link README to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ plt.show()
 
 ## Installation
 
+See [docs/installation.html](docs/installation.html) for full setup details.
 Requires **Python >=3.9** and it is recommended to work inside a virtual
 environment. Install the latest release from
 [PyPI](https://pypi.org/project/sheshe/):
@@ -58,6 +59,7 @@ gradients and Hessians.
 
 ## Reproducibility
 
+Environment and benchmarking notes are in [docs/reproducibility.html](docs/reproducibility.html).
 This project was developed and tested on:
 
 - **OS:** Ubuntu 24.04.2 LTS
@@ -77,6 +79,8 @@ PYTHONPATH=src pytest -q
 ---
 
 ## Quick API
+
+A full reference is available in [docs/quick_api.html](docs/quick_api.html).
 
 The library exposes seven main objects:
 
@@ -877,20 +881,8 @@ python experiments/paper_experiments.py --runs 5
 ---
 
 ## Key parameters
-- `base_2d_rays` → controls angular resolution in 2D (32 by default). 3D scales
-  to ~34; d>3 uses subspaces.
-- `direction` → "center_out" | "outside_in" to locate the inflection point.
-- `scan_radius_factor`, `scan_steps` → size and resolution of the radial scan.
-- `optim_method` → `"gradient_ascent"` (default) or `"trust_region_newton"`; the
-  trust-region variant uses gradients and Hessians to solve quadratic
-  subproblems inside an adaptive radius and respects box constraints.
-- `grad_*` → hyperparameters of gradient ascent (rate, iterations, tolerances;
-  used only when `optim_method="gradient_ascent"`).
-- `max_subspaces` → max number of subspaces considered when d>3.
-- `density_alpha` / `density_k` → optional density penalty computed with an
-  HNSW k‑NN search (via `hnswlib`) to keep centers inside the data cloud. The
-  normalized value is multiplied by `(density(x))**density_alpha`; set
-  `density_alpha=0` to disable.
+See [docs/key_parameters.html](docs/key_parameters.html) for a complete list of
+hyperparameters and their effects.
 
 ---
 
@@ -904,6 +896,7 @@ python experiments/paper_experiments.py --runs 5
 ---
 
 ## Limitations
+Further details are available in [docs/limitations.html](docs/limitations.html).
 - Depends on the **surface** produced by the base model (can be rough in RF).
 - In high dimension, the boundary is an **approximation** (subspaces).
 - Finds **local maxima** (does not guarantee the global one), mitigated with

--- a/docs/key_parameters.html
+++ b/docs/key_parameters.html
@@ -1,0 +1,61 @@
+---
+layout: default
+title: "Key parameters"
+description: "Important hyperparameters and their effects"
+nav_order: 7
+---
+
+<link rel="stylesheet" href="style.css">
+
+<h1>Key parameters</h1>
+
+<p>Main hyperparameters that influence search and clustering.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Effect</th>
+      <th>Reference</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>base_2d_rays</code></td>
+      <td>Controls angular resolution in 2D (default 32). 3D scales to ~34; higher dimensions use subspaces.</td>
+      <td><a href="modalboundaryclustering.html">ModalBoundaryClustering</a></td>
+    </tr>
+    <tr>
+      <td><code>direction</code></td>
+      <td>Selects scan direction to locate the inflection point: <code>center_out</code> or <code>outside_in</code>.</td>
+      <td><a href="modalboundaryclustering.html">ModalBoundaryClustering</a></td>
+    </tr>
+    <tr>
+      <td><code>scan_radius_factor</code>, <code>scan_steps</code></td>
+      <td>Set size and resolution of the radial scan around seed points.</td>
+      <td><a href="modalboundaryclustering.html">ModalBoundaryClustering</a></td>
+    </tr>
+    <tr>
+      <td><code>optim_method</code></td>
+      <td>Choose between <code>gradient_ascent</code> (default) or <code>trust_region_newton</code> for local maximisation.</td>
+      <td><a href="shushu.html">ShuShu</a></td>
+    </tr>
+    <tr>
+      <td><code>grad_*</code></td>
+      <td>Hyperparameters for gradient ascent (rate, iterations, tolerances); used when <code>optim_method="gradient_ascent"</code>.</td>
+      <td><a href="shushu.html">ShuShu</a></td>
+    </tr>
+    <tr>
+      <td><code>max_subspaces</code></td>
+      <td>Maximum number of subspaces considered when dimensionality &gt; 3.</td>
+      <td><a href="subspacescout.html">SubspaceScout</a></td>
+    </tr>
+    <tr>
+      <td><code>density_alpha</code>, <code>density_k</code></td>
+      <td>Optional density penalty using HNSW k‑NN to keep centres inside the data cloud; disable with <code>density_alpha=0</code>.</td>
+      <td><a href="modalboundaryclustering.html">ModalBoundaryClustering</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Defaults favour speed; see <a href="highlights.html">Highlights</a> for performance tips and <a href="limitations.html">Limitations</a> for known constraints.</p>


### PR DESCRIPTION
## Summary
- add `docs/key_parameters.html` describing core hyperparameters and linking to technical pages
- update README to reference installation, reproducibility, quick API, key parameters and limitations docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b713a9d48c832cbd41b0f6f1f4478f