### PR TITLE
docs: add performance tips guide

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -35,6 +35,9 @@ PYTHONPATH=src pytest tests/test_basic.py::test_import_and_fit -q
 </code></pre>
 <p>See <a href="./installation.html">Installation</a> for full instructions.</p>
 
+<h2>Performance tips</h2>
+<p><a href="performance_tips.html">Performance Tips</a> outlines heuristics and parameter tweaks for large datasets.</p>
+
 <h2>Predictors</h2>
 
 <p>The project exposes several predictors and utilities. Each section below describes one of them in more detail:</p>

--- a/docs/performance_tips.html
+++ b/docs/performance_tips.html
@@ -1,0 +1,29 @@
+---
+layout: default
+title: "Performance Tips"
+description: "Heuristics and tuning for faster exploration"
+nav_order: 9
+---
+
+<link rel="stylesheet" href="style.css">
+
+<h1>Performance Tips</h1>
+
+<h2>Heuristics</h2>
+<p>SheShe applies simple rules to keep runtimes manageable. The primary one is <code>auto_rays_by_dim</code>, which caps <code>base_2d_rays</code> as dimensionality grows:</p>
+<ul>
+  <li>2–24 features → use the full <code>base_2d_rays</code> value (default 32).</li>
+  <li>25–64 features → cap <code>base_2d_rays</code> at 16.</li>
+  <li>65+ features → cap <code>base_2d_rays</code> at 12.</li>
+</ul>
+<p>Disable this behaviour with <code>auto_rays_by_dim=False</code> to keep the original ray count.</p>
+
+<h2>High-dimensional datasets</h2>
+<p>Large feature spaces require additional care. Consider the following adjustments when dealing with tens or hundreds of dimensions:</p>
+<ul>
+  <li><strong>Reduce rays</strong>: set <code>base_2d_rays</code> to 16 or 12 when <code>auto_rays_by_dim</code> is disabled or a lower cap is needed.</li>
+  <li><strong>Trim scan steps</strong>: drop <code>scan_steps</code> from 24 to 12 to halve the evaluations along each ray.</li>
+  <li><strong>Limit exploration</strong>: decrease <code>n_max_seeds</code> and <code>max_subspaces</code> to restrict the number of starting points and subspaces scanned.</li>
+  <li><strong>Preselect subspaces</strong>: run <a href="subspacescout.html">SubspaceScout</a> to focus on promising feature pairs before launching heavier searches.</li>
+</ul>
+<p>See the <a href="../README.md#performance-tips">README</a> for additional context on how these parameters interact.</p>


### PR DESCRIPTION
## Summary
- document heuristics such as `auto_rays_by_dim` in a new Performance Tips page
- advise how to tune ray count, scan steps, and exploration settings for high-dimensional datasets
- link the new guide from the main docs index

## Testing
- `PYTHONPATH=src pytest -q`
- `lychee docs/index.html docs/performance_tips.html` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b713a6c790832cb620cacf1c404e84