### PR TITLE
docs: point README files to hosted docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install sheshe
 ```
 
 ## Documentation
-See the [documentation](docs/index.html) for installation, API reference and guides.
+See the [documentation](https://jcval94.github.io/SheShe/) for installation, API reference and guides.
 
 ## Author
 SheShe is authored by José Carlos Del Valle – [LinkedIn](https://www.linkedin.com/in/jose-carlos-del-valle/) | [Portfolio](https://jcval94.github.io/Portfolio/)

--- a/README_ES.md
+++ b/README_ES.md
@@ -16,7 +16,7 @@ pip install sheshe
 ```
 
 ## Documentación
-Consulta la [documentación](docs/index.html) para guías e información detallada.
+Consulta la [documentación](https://jcval94.github.io/SheShe/) para guías e información detallada.
 
 ## Autor
 SheShe es desarrollado por José Carlos Del Valle – [LinkedIn](https://www.linkedin.com/in/jose-carlos-del-valle/) | [Portafolio](https://jcval94.github.io/Portfolio/)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -2,6 +2,8 @@
 
 Este directorio contiene los resultados de pruebas de rendimiento y calidad para `SheShe` comparado con otros algoritmos clásicos.
 
+Para documentación completa de SheShe, visita [jcval94.github.io/SheShe](https://jcval94.github.io/SheShe/).
+
 ## Calidad de clustering
 
 Los siguientes resultados muestran el mejor `Adjusted Rand Index (ARI)` y `V-measure` alcanzados por cada algoritmo en distintos conjuntos de datos.

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -3,6 +3,8 @@
 Este directorio contiene scripts reproducibles que generan las tablas y figuras
 utilizadas en el artículo de SheShe.
 
+Para documentación completa de SheShe, visita [jcval94.github.io/SheShe](https://jcval94.github.io/SheShe/).
+
 Las métricas reflejan el nuevo modo de rayos `grad`, que reemplaza al anterior
 `grid` con mejoras significativas de rendimiento (ver
 [benchmark/README.md](../benchmark/README.md)).


### PR DESCRIPTION
## Summary
- Link README and other project documentation to https://jcval94.github.io/SheShe/

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b71db81208832cbc2ea8499d99e36f