### PR TITLE
Enable vertical scrolling for experiments tables

### DIFF
--- a/benchmark/generate_experiments_page.py
+++ b/benchmark/generate_experiments_page.py
@@ -70,7 +70,9 @@ def main():
         parts.append(f'<h2>{name}</h2>')
         if desc:
             parts.append(f'<p>{desc}</p>')
+        parts.append('<div class="scroll-table">')
         parts.append(df.to_html(index=False))
+        parts.append('</div>')
 
     DOC_FILE.write_text('\n'.join(parts), encoding='utf-8')
 

--- a/docs/experiments_benchmarks.html
+++ b/docs/experiments_benchmarks.html
@@ -9,6 +9,7 @@ nav_order: 98
 <p>This page summarises results from scripts in the <code>benchmark/</code> directory. Each script runs an A/B style comparison with several repetitions and reports the mean runtime, a speedup ratio and any additional metrics specific to the experiment.</p>
 <h2>cheche_vs_shushu_ab_test.csv</h2>
 <p>Runtime comparison between CheChe.fit and a ShuShu-style frontier computation (see <code>cheche_vs_shushu_ab_test.py</code> for details).</p>
+<div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -25,8 +26,10 @@ nav_order: 98
     </tr>
   </tbody>
 </table>
+</div>
 <h2>fit_profile.csv</h2>
 <p>Profiling data for <code>fit</code> performance (script: <code>profile_fit.py</code>).</p>
+<div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -177,8 +180,10 @@ nav_order: 98
     </tr>
   </tbody>
 </table>
+</div>
 <h2>large_df_benchmark_results.csv</h2>
 <p>Benchmark measuring fit time scaling with large datasets (script: <code>large_df_benchmark.py</code>).</p>
+<div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -233,8 +238,10 @@ nav_order: 98
     </tr>
   </tbody>
 </table>
+</div>
 <h2>newton_vs_gradient_ab_test.csv</h2>
 <p>Gradient ascent versus Newton trust-region on a quadratic objective; includes evaluation counts (script: <code>newton_vs_gradient_ab_test.py</code>).</p>
+<div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -261,8 +268,10 @@ nav_order: 98
     </tr>
   </tbody>
 </table>
+</div>
 <h2>numba_finite_diff_ab_test.csv</h2>
 <p>Effect of numba acceleration on finite-difference gradients (results generated externally).</p>
+<div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -281,8 +290,10 @@ nav_order: 98
     </tr>
   </tbody>
 </table>
+</div>
 <h2>parallel_jobs_ab_test.csv</h2>
 <p>ModalScoutEnsemble fitted sequentially (<code>n_jobs=1</code>) versus in parallel (<code>n_jobs=-1</code>) (script: <code>parallel_jobs_ab_test.py</code>).</p>
+<div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -334,8 +345,10 @@ nav_order: 98
     </tr>
   </tbody>
 </table>
+</div>
 <h2>percentile_drop_ab_test.csv</h2>
 <p>Vectorised <code>find_percentile_drop</code> compared to the previous loop-based version (script: <code>percentile_drop_ab_test.py</code>).</p>
+<div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -374,8 +387,10 @@ nav_order: 98
     </tr>
   </tbody>
 </table>
+</div>
 <h2>ray_mode_ab_test.csv</h2>
 <p>ModalBoundaryClustering ray modes 'grid' and 'grad' compared for speed and accuracy (script: <code>ray_mode_ab_test.py</code>).</p>
+<div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -409,8 +424,10 @@ nav_order: 98
     </tr>
   </tbody>
 </table>
+</div>
 <h2>stop_criteria_results.csv</h2>
 <p>Impact of different stop criteria on convergence behaviour (script: <code>profile_fit.py</code>).</p>
+<div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -473,8 +490,10 @@ nav_order: 98
     </tr>
   </tbody>
 </table>
+</div>
 <h2>subspace_ab_results.csv</h2>
 <p>Comparison of subspace search strategies.</p>
+<div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -516,7 +535,9 @@ nav_order: 98
     </tr>
   </tbody>
 </table>
+</div>
 <h2>unsupervised_results.csv</h2>
+<div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -4211,10 +4232,87 @@ nav_order: 98
       <td>1.000000</td>
       <td>1.000000</td>
     </tr>
+    <tr>
+      <td>california_housing</td>
+      <td>KMeans</td>
+      <td>n_clusters=2</td>
+      <td>0</td>
+      <td>0.043777</td>
+      <td>5.787810e-04</td>
+      <td>1.375000</td>
+      <td>0.000</td>
+      <td>0.044356</td>
+      <td>0.005554</td>
+      <td>0.009002</td>
+      <td>0.018687</td>
+      <td>0.012151</td>
+    </tr>
+    <tr>
+      <td>california_housing</td>
+      <td>KMeans</td>
+      <td>n_clusters=3</td>
+      <td>0</td>
+      <td>0.006800</td>
+      <td>6.787700e-04</td>
+      <td>0.125000</td>
+      <td>0.000</td>
+      <td>0.007478</td>
+      <td>0.003650</td>
+      <td>0.011921</td>
+      <td>0.015137</td>
+      <td>0.013338</td>
+    </tr>
+    <tr>
+      <td>california_housing</td>
+      <td>KMeans</td>
+      <td>n_clusters=4</td>
+      <td>0</td>
+      <td>0.004950</td>
+      <td>6.420050e-04</td>
+      <td>0.000000</td>
+      <td>0.000</td>
+      <td>0.005592</td>
+      <td>0.005658</td>
+      <td>0.016124</td>
+      <td>0.016267</td>
+      <td>0.016195</td>
+    </tr>
+    <tr>
+      <td>california_housing</td>
+      <td>KMeans</td>
+      <td>n_clusters=5</td>
+      <td>0</td>
+      <td>0.005701</td>
+      <td>4.696770e-04</td>
+      <td>0.000000</td>
+      <td>0.000</td>
+      <td>0.006171</td>
+      <td>0.000044</td>
+      <td>0.015527</td>
+      <td>0.013404</td>
+      <td>0.014388</td>
+    </tr>
+    <tr>
+      <td>california_housing</td>
+      <td>KMeans</td>
+      <td>n_clusters=6</td>
+      <td>0</td>
+      <td>0.004719</td>
+      <td>7.201350e-04</td>
+      <td>0.000000</td>
+      <td>0.000</td>
+      <td>0.005440</td>
+      <td>-0.000944</td>
+      <td>0.017884</td>
+      <td>0.013923</td>
+      <td>0.015657</td>
+    </tr>
   </tbody>
 </table>
+</div>
 <h2>unsupervised_results_summary.csv</h2>
 <p>Summary of unsupervised modal clustering benchmarks.</p>
+<div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -9810,3 +9908,4 @@ nav_order: 98
     </tr>
   </tbody>
 </table>
+</div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -66,3 +66,9 @@
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
+
+.main-content .scroll-table {
+  max-height: 400px;
+  overflow-y: auto;
+  margin-bottom: 1.5rem;
+}


### PR DESCRIPTION
## Summary
- Wrap each benchmark table in a scrollable container
- Add CSS for `.scroll-table` to allow vertical scrolling
- Regenerate `experiments_benchmarks.html` with new structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74ad7d6a4832c95d88ad4421fb0eb