### PR TITLE
feat: unify score interface across predictors

### DIFF
--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -58,6 +58,15 @@ ch = CheChe().fit(
 )
 ch.plot_pairs(X, class_index=0)
 </code></pre>
+<pre><code class="language-python">
+from sklearn.linear_model import LogisticRegression
+
+model = LogisticRegression(max_iter=200).fit(X, y)
+CheChe().fit(X, y, score_model=model)
+
+score_fn = lambda Z: model.predict_proba(Z)[:, 0]
+CheChe().fit(X, score_fn=score_fn)
+</code></pre>
 <h2>Parameters</h2>
 <ul>
 <li><code>random_state</code> (<code>int</code> or <code>None</code>, default <code>None</code>): seed for reproducibility.

--- a/docs/shushu.html
+++ b/docs/shushu.html
@@ -62,6 +62,10 @@ def paraboloid(Z):
 
 sc = ShuShu(random_state=0).fit(np.random.rand(100, 2), score_fn=paraboloid)
 print(sc.centroids_)
+
+from sklearn.linear_model import LogisticRegression
+model = LogisticRegression(max_iter=200).fit(X, y)
+ShuShu(random_state=0).fit(X, y, score_model=model)
 </code></pre>
 <h2>Parameters</h2>
 <ul>


### PR DESCRIPTION
## Summary
- allow ModalBoundaryClustering and ModalScoutEnsemble to accept `score_model` and `score_fn`
- propagate extra fit kwargs through helper methods for API consistency
- document usage of `score_model` and `score_fn` in CheChe and ShuShu docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b74a9a74fc832c96f1b627be6e01fc