### PR TITLE
feat: add optional histograms to 2d plots

### DIFF
--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -15,7 +15,7 @@ from sheshe import CheChe
 
 X, y = load_iris(return_X_y=True)
 che = CheChe().fit(X, y)
-che.plot_pairs(X, y, max_pairs=1)
+che.plot_pairs(X, y, max_pairs=1, show_histograms=True)
 plt.show()
 </code></pre>
 <p>Computes convex-hull frontiers for selected feature pairs and provides simple</p>
@@ -27,7 +27,7 @@ plt.show()
 from sheshe import CheChe
 cc = CheChe()
 cc.fit(X, y)
-cc.plot_pairs(X)
+cc.plot_pairs(X, show_histograms=True)
 </code></pre>
 
 <h2>Usage examples</h2>
@@ -56,7 +56,7 @@ ch = CheChe().fit(
     feature_names=["sepal length", "sepal width", "petal length", "petal width"],
     mapping_level=2,  # use every other sample
 )
-ch.plot_pairs(X, class_index=0)
+ch.plot_pairs(X, class_index=0, show_histograms=True)
 </code></pre>
 <pre><code class="language-python">
 from sklearn.linear_model import LogisticRegression
@@ -108,8 +108,8 @@ CheChe().fit(X, score_fn=score_fn)
 </li>
 <li><code>decision_function(X)</code> – negative distances to region centres.
 </li>
-<li><code>plot_pairs(X, class_index=None, feature_names=None)</code> – scatter plots with
- frontier overlays for stored pairs.
+<li><code>plot_pairs(X, class_index=None, feature_names=None, show_histograms=False)</code> – scatter plots with
+ frontier overlays for stored pairs and optional marginal histograms.
 </li>
 <li><code>plot_classes(X, y, ...)</code> – plot frontiers for each class when in supervised
  mode.

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@ from sheshe import ModalBoundaryClustering
 
 X, y = load_iris(return_X_y=True)
 sh = ModalBoundaryClustering().fit(X, y)
-sh.plot_pairs(X, y, max_pairs=1)
+sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
 plt.show()
 </code></pre>
 

--- a/docs/modalboundaryclustering.html
+++ b/docs/modalboundaryclustering.html
@@ -207,8 +207,8 @@ reg_retrained = ModalBoundaryClustering(
 </li>
 <li><code>interpretability_summary(feature_names=None)</code> – tabular region summary.
 </li>
-<li><code>plot_pairs(X, y=None, max_pairs=None)</code> – 2D decision plots for feature
- pairs.
+<li><code>plot_pairs(X, y=None, max_pairs=None, show_histograms=False)</code> – 2D decision plots for feature
+ pairs with optional marginal histograms.
 </li>
 <li><code><a href="visualization_3d.html">plot_pair_3d(X, pair, class_label=None, grid_res=50, alpha_surface=0.6, engine="matplotlib")</a></code> – render a 3D surface for a feature pair.</li>
 </ul>

--- a/docs/modalscoutensemble.html
+++ b/docs/modalscoutensemble.html
@@ -15,7 +15,7 @@ from sheshe import ModalScoutEnsemble
 
 X, y = load_iris(return_X_y=True)
 mse = ModalScoutEnsemble().fit(X, y)
-mse.plot_pairs(X, y, max_pairs=1)
+mse.plot_pairs(X, y, max_pairs=1, show_histograms=True)
 plt.show()
 </code></pre>
 <p>Ensemble that applies <code>ModalBoundaryClustering</code> on the most promising</p>
@@ -155,8 +155,8 @@ print(mse.predict_proba(X[:5]))
 </li>
 <li><code>predict_regions(X)</code> – DataFrame with region assignments.
 </li>
-<li><code>plot_pairs(X, y=None, **kwargs)</code> – delegate to
- <code>ModalBoundaryClustering.plot_pairs</code> for a selected submodel.
+<li><code>plot_pairs(X, y=None, show_histograms=False, **kwargs)</code> – delegate to
+ <code>ModalBoundaryClustering.plot_pairs</code> for a selected submodel, including optional marginal histograms.
 </li>
 <li><code>plot_pair_3d(X, pair, **kwargs)</code> – 3D surface for a feature pair of a
  submodel.

--- a/docs/regioninterpreter.html
+++ b/docs/regioninterpreter.html
@@ -17,7 +17,7 @@ iris = load_iris()
 X, y = iris.data, iris.target
 sh = ModalBoundaryClustering().fit(X, y)
 cards = RegionInterpreter(feature_names=iris.feature_names).summarize(sh.regions_)
-sh.plot_pairs(X, y, max_pairs=1)
+sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
 plt.show()
 </code></pre>
 <p>Converts <code>ClusterRegion</code> objects into compact human‑readable rule sets.</p>

--- a/docs/shushu.html
+++ b/docs/shushu.html
@@ -15,7 +15,7 @@ from sheshe import ShuShu
 
 X, y = load_iris(return_X_y=True)
 sh = ShuShu().fit(X, y)
-sh.plot_pairs(X, y, max_pairs=1)
+sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
 plt.show()
 </code></pre>
 <p>Gradient-based optimiser that searches for local maxima of a scalar score or</p>
@@ -97,7 +97,7 @@ ShuShu(random_state=0).fit(X, y, score_model=model)
 </li>
 <li><code>fit_transform(X, y=None, **kwargs)</code> – combine <code>fit</code> and <code>transform</code>.
 </li>
-<li><code>plot_pairs(X, y=None, max_pairs=None)</code> – scatter plots for feature pairs.
+<li><code>plot_pairs(X, y=None, max_pairs=None, show_histograms=False)</code> – scatter plots for feature pairs with optional marginal histograms.
 </li>
 <li><code>plot_classes(X, y, grid_res=200, contour_levels=None, max_paths=20,
  show_paths=True)</code> – visualise class-wise score surfaces.

--- a/docs/subspacescout.html
+++ b/docs/subspacescout.html
@@ -16,7 +16,7 @@ from sheshe import SubspaceScout, ModalBoundaryClustering
 X, y = load_iris(return_X_y=True)
 scout = SubspaceScout().fit(X, y)
 pair = scout.results_[0]["features"]
-ModalBoundaryClustering().fit(X, y).plot_pairs(X, y, pairs=[pair])
+ModalBoundaryClustering().fit(X, y).plot_pairs(X, y, pairs=[pair], show_histograms=True)
 plt.show()
 </code></pre>
 <p>Identifies informative feature subsets so that <code>ModalBoundaryClustering</code> can</p>

--- a/src/sheshe/cheche.py
+++ b/src/sheshe/cheche.py
@@ -584,6 +584,7 @@ class CheChe:
         *,
         class_index: Optional[int] = None,
         feature_names: Optional[Sequence[str]] = None,
+        show_histograms: bool = False,
     ):
         """Plot the frontiers discovered by this instance on ``X``.
 
@@ -598,6 +599,8 @@ class CheChe:
         feature_names:
             Optional names for the features. If ``None``, ``self.feature_names_``
             is used.
+        show_histograms:
+            If ``True``, draw marginal histograms for each dimension.
 
         Returns
         -------
@@ -607,6 +610,7 @@ class CheChe:
         """
 
         import matplotlib.pyplot as plt  # local import to keep optional dependency
+        from mpl_toolkits.axes_grid1 import make_axes_locatable  # pragma: no cover - optional dependency
 
         if feature_names is None:
             feature_names = self.feature_names_
@@ -643,6 +647,14 @@ class CheChe:
             if feature_names is not None and len(feature_names) > max(i, j):
                 ax.set_xlabel(feature_names[i])
                 ax.set_ylabel(feature_names[j])
+            if show_histograms:
+                divider = make_axes_locatable(ax)
+                ax_hist_x = divider.append_axes("top", 1.2, pad=0.1, sharex=ax)
+                ax_hist_y = divider.append_axes("right", 1.2, pad=0.1, sharey=ax)
+                ax_hist_x.hist(pts[:, 0], color="lightgray", bins=20)
+                ax_hist_y.hist(pts[:, 1], color="lightgray", bins=20, orientation="horizontal")
+                ax_hist_x.tick_params(axis="x", labelbottom=False)
+                ax_hist_y.tick_params(axis="y", labelleft=False)
             ax.legend()
 
         fig.tight_layout()

--- a/src/sheshe/modal_scout_ensemble.py
+++ b/src/sheshe/modal_scout_ensemble.py
@@ -869,6 +869,7 @@ class ModalScoutEnsemble(BaseEstimator):
     feature_names: Optional[Sequence[str]] = None,
     block_size: Optional[int] = None,
     max_classes: Optional[int] = None,
+    show_histograms: bool = False,
   ) -> None:
     """Visualiza superficies 2D para un submodelo específico.
 
@@ -877,6 +878,7 @@ class ModalScoutEnsemble(BaseEstimator):
     el submodelo dentro del ensamble.
     ``feature_names`` permite especificar nombres globales de las features,
     que se ajustarán al subespacio del modelo elegido.
+    ``show_histograms`` permite dibujar histogramas marginales en cada gráfico.
     """
     mbc, feats = self._get_submodel(model_idx)
     feats_list = list(feats)
@@ -896,6 +898,7 @@ class ModalScoutEnsemble(BaseEstimator):
       feature_names=sub_names,
       block_size=block_size,
       max_classes=max_classes,
+      show_histograms=show_histograms,
     )
 
   def plot_classes(self, X: np.ndarray, y: np.ndarray, **kwargs):

--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -2561,6 +2561,7 @@ class ModalBoundaryClustering(BaseEstimator):
         grid_res: int = 200,
         alpha_surface: float = 0.6,
         show_centroids: bool = True,
+        show_histograms: bool = False,
     ) -> plt.Figure:
         """Draw the probability surface for a pair of features and one class.
 
@@ -2584,6 +2585,8 @@ class ModalBoundaryClustering(BaseEstimator):
             Surface transparency.
         show_centroids : bool, default=True
             Whether to display cluster centroids.
+        show_histograms : bool, default=False
+            Whether to draw marginal histograms for each dimension.
 
         Returns
         -------
@@ -2611,6 +2614,7 @@ class ModalBoundaryClustering(BaseEstimator):
         Z = self._predict_value_real(X_grid, class_idx=cls_idx).reshape(XI.shape)
 
         fig, ax = plt.subplots(figsize=(6, 5))
+        from mpl_toolkits.axes_grid1 import make_axes_locatable  # pragma: no cover - optional dependency
         ax.set_title(
             f"Prob. clase '{class_label}' vs ({feature_names[i]},{feature_names[j]})"
         )
@@ -2677,6 +2681,14 @@ class ModalBoundaryClustering(BaseEstimator):
                     s=80,
                     label=f"centro {reg.cluster_id} ({class_label})",
                 )
+        if show_histograms:
+            divider = make_axes_locatable(ax)
+            ax_hist_x = divider.append_axes("top", 1.2, pad=0.1, sharex=ax)
+            ax_hist_y = divider.append_axes("right", 1.2, pad=0.1, sharey=ax)
+            ax_hist_x.hist(xi, color="lightgray", bins=20)
+            ax_hist_y.hist(xj, color="lightgray", bins=20, orientation="horizontal")
+            ax_hist_x.tick_params(axis="x", labelbottom=False)
+            ax_hist_y.tick_params(axis="y", labelleft=False)
 
         ax.set_xlabel(feature_names[i])
         ax.set_ylabel(feature_names[j])
@@ -2696,6 +2708,7 @@ class ModalBoundaryClustering(BaseEstimator):
         alpha_surface: float = 0.6,
         max_classes: Optional[int] = None,
         show_centroids: bool = True,
+        show_histograms: bool = False,
     ) -> plt.Figure:
         """Draw predicted-value surface and decile regions for a feature pair.
 
@@ -2716,6 +2729,8 @@ class ModalBoundaryClustering(BaseEstimator):
             Surface transparency.
         show_centroids : bool, default=True
             Whether to display cluster centroids.
+        show_histograms : bool, default=False
+            Whether to draw marginal histograms for each dimension.
 
         Returns
         -------
@@ -2758,6 +2773,7 @@ class ModalBoundaryClustering(BaseEstimator):
         n_dec = 10 if max_classes is None else min(10, max_classes)
 
         fig, ax = plt.subplots(figsize=(6, 5))
+        from mpl_toolkits.axes_grid1 import make_axes_locatable  # pragma: no cover - optional dependency
         ax.set_title(
             f"Deciles de y_pred vs ({feature_names[i]},{feature_names[j]})"
         )
@@ -2795,6 +2811,14 @@ class ModalBoundaryClustering(BaseEstimator):
                     s=80,
                     label=f"centro {reg.cluster_id}",
                 )
+        if show_histograms:
+            divider = make_axes_locatable(ax)
+            ax_hist_x = divider.append_axes("top", 1.2, pad=0.1, sharex=ax)
+            ax_hist_y = divider.append_axes("right", 1.2, pad=0.1, sharey=ax)
+            ax_hist_x.hist(xi, color="lightgray", bins=20)
+            ax_hist_y.hist(xj, color="lightgray", bins=20, orientation="horizontal")
+            ax_hist_x.tick_params(axis="x", labelbottom=False)
+            ax_hist_y.tick_params(axis="y", labelleft=False)
 
         ax.set_xlabel(feature_names[i])
         ax.set_ylabel(feature_names[j])
@@ -2811,6 +2835,7 @@ class ModalBoundaryClustering(BaseEstimator):
         block_size: Optional[int] = None,
         max_classes: Optional[int] = None,
         show_centroids: bool = True,
+        show_histograms: bool = False,
     ):
         """Visualize 2D surfaces for feature pairs.
 
@@ -2842,6 +2867,8 @@ class ModalBoundaryClustering(BaseEstimator):
             If ``None`` all are shown.
         show_centroids : bool, default=True
             Whether to display cluster centroids.
+        show_histograms : bool, default=False
+            Whether to draw marginal histograms for each dimension.
 
         Returns
         -------
@@ -2909,6 +2936,7 @@ class ModalBoundaryClustering(BaseEstimator):
                         class_colors,
                         feature_names,
                         show_centroids=show_centroids,
+                        show_histograms=show_histograms,
                     )
                     if block_size:
                         block_figs.append(fig)
@@ -2927,6 +2955,7 @@ class ModalBoundaryClustering(BaseEstimator):
                     y_vals,
                     max_classes=max_classes,
                     show_centroids=show_centroids,
+                    show_histograms=show_histograms,
                 )
                 if block_size:
                     block_figs.append(fig)

--- a/src/sheshe/shushu.py
+++ b/src/sheshe/shushu.py
@@ -1037,6 +1037,7 @@ class ShuShu:
         max_pairs: Optional[int] = None,
         feature_names: Optional[Sequence[str]] = None,
         show_centroids: bool = True,
+        show_histograms: bool = False,
     ):
         """Simple 2D scatter plots for feature pairs.
 
@@ -1054,9 +1055,12 @@ class ShuShu:
             or generic ``xj`` names.
         show_centroids : bool, default ``True``
             Whether to draw cluster centroids when available.
+        show_histograms : bool, default ``False``
+            Whether to display marginal histograms for each dimension.
         """
 
         import matplotlib.pyplot as plt  # pragma: no cover - optional dependency
+        from mpl_toolkits.axes_grid1 import make_axes_locatable  # pragma: no cover - optional dependency
 
         X = np.asarray(X, dtype=float)
         n, d = X.shape
@@ -1094,6 +1098,14 @@ class ShuShu:
                         cid = reg.get("cluster_id")
                         lbl = f"centro {cid}" if cid is not None else "centro"
                         ax.scatter(ctr[i], ctr[j], marker="X", s=80, color="k", label=lbl)
+            if show_histograms:
+                divider = make_axes_locatable(ax)
+                ax_hist_x = divider.append_axes("top", 1.2, pad=0.1, sharex=ax)
+                ax_hist_y = divider.append_axes("right", 1.2, pad=0.1, sharey=ax)
+                ax_hist_x.hist(X[:, i], color="lightgray", bins=20)
+                ax_hist_y.hist(X[:, j], color="lightgray", bins=20, orientation="horizontal")
+                ax_hist_x.tick_params(axis="x", labelbottom=False)
+                ax_hist_y.tick_params(axis="y", labelleft=False)
             ax.set_xlabel(feature_names[i])
             ax.set_ylabel(feature_names[j])
             ax.legend(loc="best")

--- a/tests/test_plot_pairs.py
+++ b/tests/test_plot_pairs.py
@@ -78,3 +78,26 @@ def test_shushu_plot_pairs_show_centroids():
     assert all("centro" not in txt for txt in texts)
     plt.close('all')
 
+
+def test_plot_pairs_histograms():
+    X, y = load_iris(return_X_y=True)
+    sh = ModalBoundaryClustering(random_state=0).fit(X, y)
+    sh.plot_pairs(X, y, max_pairs=1, max_classes=1, show_histograms=True)
+    fig = plt.gcf()
+    assert len(fig.axes) >= 4
+    plt.close('all')
+
+
+def test_shushu_plot_pairs_histograms():
+    X, y = load_iris(return_X_y=True)
+    sh = ShuShu(
+        k=5,
+        rf_estimators=5,
+        importance_sample_size=60,
+        max_iter=5,
+        random_state=0,
+    ).fit(X, y)
+    fig, _ = sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+    assert len(fig.axes) == 3
+    plt.close('all')
+


### PR DESCRIPTION
## Summary
- add `show_histograms` flag to 2D plot helpers
- display marginal histograms when requested
- cover new option with tests
- document `show_histograms` in user guides

## Testing
- `PYTHONPATH=src pytest tests/test_plot_pairs.py`


------
https://chatgpt.com/codex/tasks/task_e_68b76b119fa4832c87b01eb207839203