### PR TITLE
docs: add mathematical foundations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ SheShe turns probabilistic models into guided explorers of their decision surfac
 - Rule extraction and subspace exploration
 - 2D/3D plotting utilities
 
+## Mathematical Overview
+SheShe approximates the optimisation problem <code>max_x f(x)</code> by climbing gradient-ascent paths toward local maxima and delineating neighbourhoods around them. Detailed derivations for each module are provided in the documentation.
+
 ## Installation
 Requires Python ≥3.9. Install from [PyPI](https://pypi.org/project/sheshe/):
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -8,6 +8,9 @@ SheShe convierte cualquier modelo probabilístico en un explorador guiado de su 
 - Extracción de reglas y exploración de subespacios
 - Herramientas de graficado 2D/3D
 
+## Resumen matemático
+SheShe aproxima el problema <code>max_x f(x)</code> siguiendo trayectorias de ascenso por gradiente hacia máximos locales y delimitando las regiones vecinas. Las ecuaciones detalladas se encuentran en la documentación.
+
 ## Instalación
 Requiere Python ≥3.9. Instala desde [PyPI](https://pypi.org/project/sheshe/):
 

--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -22,6 +22,9 @@ plt.show()
 <p>2D visualisations. Useful for exploring decision boundaries or cluster shapes,</p>
 <p>it can subsample points via <code>mapping_level</code> and plot frontiers per class or</p>
 <p>for scalar score functions.</p>
+<h2>Mathematical formulation</h2>
+<p>For feature pair <code>(i,j)</code>, CheChe projects samples with <code>P_{ij}(x) = (x_i, x_j)</code>. QuickHull constructs the convex hull <code>H</code> of these projections.</p>
+<p>The decision function outputs the negative distance from the projected point to the hull centroid: <code>-‖P_{ij}(x) - c_H‖</code>.</p>
 <h2>Example</h2>
 <pre><code class="language-python">
 from sheshe import CheChe

--- a/docs/how_it_works.html
+++ b/docs/how_it_works.html
@@ -10,6 +10,10 @@ nav_order: 0
 
 <p>SheShe transforms a probabilistic model into an explorer of its own decision landscape. It searches for <strong>local maxima</strong> in class probability or predicted value and can outline regions around the discovered modes.</p>
 
+<h2>Mathematical foundation</h2>
+<p>Optimisation follows gradient-ascent updates <code>x_{k+1} = x_k + α∇f(x_k)</code> until the gradient norm falls below a small <code>ε</code>.</p>
+<p>Boundary scans shoot rays from each peak and locate inflection points where <code>d²f/dr² = 0</code> or a percentile drop is reached, delimiting regions around every mode. See <a href="shushu.html">ShuShu</a> and <a href="modalboundaryclustering.html">ModalBoundaryClustering</a> for details.</p>
+
 <h2>Components</h2>
 
 <h3><a href="modalboundaryclustering.html">ModalBoundaryClustering</a></h3>

--- a/docs/modalboundaryclustering.html
+++ b/docs/modalboundaryclustering.html
@@ -22,6 +22,10 @@ plt.show()
 <p>base estimator. Radial scans trace boundary surfaces around each mode and</p>
 <p>gradient ascent refines the centres, enabling both classification and regression</p>
 <p>workflows.</p>
+<h2>Mathematical formulation</h2>
+<p>Centres are refined with gradient ascent updates <code>x_{k+1} = x_k + α∇f(x_k)</code> until <code>‖∇f(x_k)‖ &lt; grad_tol</code>.</p>
+<p>From each centre, radial scans sample scores <code>f(x_k + r u)</code> along directions <code>u</code>. Scans stop when <code>∂f/∂r = 0</code> (an inflection point) or when the score falls past a percentile or drop fraction of the peak.</p>
+<p>These radii approximate a probability surface from which boundary polygons are built.</p>
 <h2>Example</h2>
 <pre><code class="language-python">
 from sheshe import ModalBoundaryClustering

--- a/docs/regioninterpreter.html
+++ b/docs/regioninterpreter.html
@@ -24,6 +24,10 @@ plt.show()
 <p>It summarises each region with axis‑aligned boxes, highlights informative</p>
 <p>projections and offers helpers like <code>pretty_print</code> for reporting. Optional</p>
 <p>LLM backends can turn the summaries into natural‑language descriptions.</p>
+<h2>Mathematical formulation</h2>
+<p>For each feature <code>j</code>, an axis‑aligned rule uses quantiles <code>[Q_q(x_j), Q_{1-q}(x_j)]</code>, capturing about <code>1-2q</code> of the data.</p>
+<p>Capped radii are flagged using the z‑score <code>z=(r-μ)/σ</code> when <code>|z| &gt; cap_threshold</code>.</p>
+<p><strong>Example:</strong> with <code>q_box=0.05</code> and values 1‑10, the rule becomes <code>[1.45, 9.55]</code>. A radius 3 with mean 2 and <code>σ=0.3</code> yields <code>z≈3.3</code>.</p>
 <h2>Example</h2>
 <pre><code class="language-python">
 from sheshe import RegionInterpreter

--- a/docs/shushu.html
+++ b/docs/shushu.html
@@ -22,6 +22,9 @@ plt.show()
 <p>class probabilities. Runs one optimisation per class when labels are given and</p>
 <p>can also operate on arbitrary user-defined score functions, returning cluster</p>
 <p>centroids for each discovered mode.</p>
+<h2>Mathematical formulation</h2>
+<p>ShuShu performs gradient-ascent updates <code>x_{t+1} = x_t + η∇f(x_t)</code> until <code>‖∇f(x_t)‖ &lt; tol</code> or a maximum iteration count is reached.</p>
+<p>When analytic gradients are unavailable, it estimates them via SPSA: <code>∂f/∂x_i ≈ (f(x + cΔ) - f(x - cΔ))/(2cΔ_i)</code> with Rademacher perturbations <code>Δ_i ∈ {−1,1}</code>.</p>
 <h2>Example</h2>
 <pre><code class="language-python">
 from sheshe import ShuShu

--- a/docs/subspacescout.html
+++ b/docs/subspacescout.html
@@ -23,6 +23,10 @@ plt.show()
 <p>run only where it matters in high-dimensional spaces. Uses mutual information or</p>
 <p>optional model-based scorers to rank interactions and employs beam search to</p>
 <p>enumerate promising subspaces.</p>
+<h2>Mathematical formulation</h2>
+<p>Mutual information between a subset <code>X</code> and target <code>Y</code> is <code>I(X;Y)=∑_{x,y} p(x,y) log(p(x,y)/(p(x)p(y)))</code>.</p>
+<p>The synergy objective for a set <code>S</code> is <code>Synergy(S) = I(S;Y) - ∑_{i∈S} I(X_i;Y)</code>, capturing information beyond individual features.</p>
+<p>Beam search grows subspaces order by order and retains those with highest scores.</p>
 <h2>Example</h2>
 <pre><code class="language-python">
 from sheshe import SubspaceScout


### PR DESCRIPTION
## Summary
- Clarify SheShe's optimisation with gradient-ascent update and inflection-based boundary scans.
- Document modal boundary clustering, ShuShu, SubspaceScout, CheChe, and RegionInterpreter with formal equations.
- Add mathematical overview sections to README files.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7707b2558832cb2636a38936fbe02