### PR TITLE
Add Spanish docs with language switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SheShe
+<div align="right"><a href="README_ES.md">ES</a></div>
 **Smart High-dimensional Edge Segmentation & Hyperboundary Explorer**
 
 SheShe turns probabilistic models into guided explorers of their decision surfaces, revealing human‑readable regions by following local maxima of class probability or predicted value.

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,4 +1,5 @@
 # SheShe
+<div align="right"><a href="README.md">EN</a></div>
 **Smart High-dimensional Edge Segmentation & Hyperboundary Explorer**
 
 SheShe convierte cualquier modelo probabilístico en un explorador guiado de su superficie de decisión, descubriendo regiones interpretables a partir de los máximos locales de probabilidad por clase o valor predicho.

--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 6
 ---
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="cheche_es.html">ES</a></div>
 
 <h1>CheChe</h1>
 

--- a/docs/cheche_es.html
+++ b/docs/cheche_es.html
@@ -1,0 +1,104 @@
+---
+layout: default
+title: CheChe
+parent: SheShe
+nav_order: 6
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="cheche.html">EN</a></div>
+
+<h1>CheChe</h1>
+
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import CheChe
+
+X, y = load_iris(return_X_y=True)
+che = CheChe().fit(X, y)
+che.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+plt.show()
+</code></pre>
+<p>Calcula fronteras de casco convexo para pares de características seleccionados y ofrece visualizaciones 2D simples.</p>
+<p>Útil para explorar fronteras de decisión o formas de clusters, puede submuestrear puntos mediante <code>mapping_level</code> y trazar fronteras por clase o para funciones de puntuación escalares.</p>
+
+<h2>Formulación matemática</h2>
+<p>Para el par de características <code>(i,j)</code>, CheChe proyecta muestras con <code>P_{ij}(x) = (x_i, x_j)</code>. QuickHull construye el casco convexo <code>H</code> de estas proyecciones.</p>
+<p>La función de decisión devuelve la distancia negativa desde el punto proyectado al centroide del casco: <code>-‖P_{ij}(x) - c_H‖</code>.</p>
+
+<h2>Ejemplo</h2>
+<pre><code class="language-python">
+from sheshe import CheChe
+cc = CheChe()
+cc.fit(X, y)
+cc.plot_pairs(X, show_histograms=True)
+</code></pre>
+
+<h2>Ejemplos de uso</h2>
+<pre><code class="language-python">
+from sheshe import CheChe
+
+che = CheChe(random_state=0)
+che.fit(X, y)                      # fit
+che.fit_predict(X, y)              # fit_predict
+che.fit(X, y).predict(X)           # predict
+che.fit(X, y).predict_proba(X)     # predict_proba
+che.fit(X, y).predict_regions(X)   # predict_regions
+che.fit(X, y).decision_function(X) # decision_function
+che.fit(X, y).save("che.joblib")   # save
+CheChe.load("che.joblib")
+</code></pre>
+
+<h2>Ejemplos adicionales</h2>
+<pre><code class="language-python">
+from sklearn.datasets import load_iris
+from sheshe import CheChe
+
+X, y = load_iris(return_X_y=True)
+ch = CheChe().fit(
+    X,
+    y,
+    feature_names=["sepal length", "sepal width", "petal length", "petal width"],
+    mapping_level=2,  # usa una de cada dos muestras
+)
+ch.plot_pairs(X, class_index=0, show_histograms=True)
+</code></pre>
+<pre><code class="language-python">
+from sklearn.linear_model import LogisticRegression
+
+model = LogisticRegression(max_iter=200).fit(X, y)
+CheChe().fit(X, y, score_model=model)
+
+score_fn = lambda Z: model.predict_proba(Z)[:, 0]
+CheChe().fit(X, score_fn=score_fn)
+</code></pre>
+
+<h2>Parámetros</h2>
+<ul>
+<li><code>random_state</code> (<code>int</code> o <code>None</code>, por defecto <code>None</code>): semilla para reproducibilidad.</li>
+</ul>
+
+<h3>Opciones de entrenamiento</h3>
+<p>El método <code>fit</code> acepta argumentos adicionales similares a la API de <code>ShuShu</code>:</p>
+<ul>
+<li><code>score_fn</code> (callable, opcional): función de puntuación escalar cuando no se proporciona <code>y</code>.</li>
+<li><code>feature_names</code> (<code>list[str]</code> o <code>None</code>): nombres de las características.</li>
+<li><code>score_model</code> (estimador, opcional): modelo usado para derivar probabilidades de clase.</li>
+<li><code>score_fn_multi</code> (<code>callable</code>, opcional): función de puntuación multiclase.</li>
+<li><code>score_fn_per_class</code> (<code>list[callable]</code>, opcional): funciones de puntuación por clase.</li>
+<li><code>max_pairs</code> (<code>int</code> o <code>None</code>, por defecto <code>10</code>): número máximo de pares de características a analizar.</li>
+<li><code>mapping_level</code> (<code>int</code> o <code>None</code>, por defecto <code>None</code>): nivel de submuestreo para la computación de fronteras.</li>
+</ul>
+
+<h2>Métodos</h2>
+<ul>
+<li><code>fit(X, y=None, **kwargs)</code> – estima fronteras 2D para pares de características.</li>
+<li><code>fit_predict(X, y=None, **kwargs)</code> – entrena el modelo y retorna predicciones inmediatamente.</li>
+<li><code>predict(X)</code> – asigna identificadores de región o etiquetas de clase.</li>
+<li><code>predict_proba(X)</code> – devuelve probabilidades de clase en modo multiclase.</li>
+<li><code>predict_regions(X)</code> – DataFrame con etiquetas e IDs de región.</li>
+<li><code>decision_function(X)</code> – distancias negativas a los centros de región.</li>
+<li><code>plot_pairs(X, class_index=None, feature_names=None, show_histograms=False)</code> – gráficos de dispersión con fronteras superpuestas para pares almacenados y opcionales histogramas marginales.</li>
+<li><code>plot_classes(X, y, ...)</code> – grafica fronteras para cada clase en modo supervisado.</li>
+</ul>
+

--- a/docs/conventions.html
+++ b/docs/conventions.html
@@ -6,6 +6,7 @@ nav_order: 99
 ---
 
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="conventions_es.html">ES</a></div>
 
 <h1>Documentation Conventions</h1>
 

--- a/docs/conventions_es.html
+++ b/docs/conventions_es.html
@@ -1,0 +1,106 @@
+---
+layout: default
+title: "Convenciones de documentación"
+description: "Estilo y reglas de migración para la documentación de SheShe"
+nav_order: 99
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="conventions.html">EN</a></div>
+
+<h1>Convenciones de documentación</h1>
+
+<h2>Front matter</h2>
+<p>Cada página HTML debe comenzar con front matter YAML. Usa la siguiente plantilla y ajusta los valores según sea necesario:</p>
+
+<pre><code class="language-python">---
+layout: default
+title: "Título de la página"
+description: "Resumen corto de la página"
+nav_order: 10
+---</code></pre>
+
+<h2>Encabezados</h2>
+<ul>
+  <li>Usa un único <code>&lt;h1&gt;</code> que coincida con el título de la página.</li>
+  <li>Estructura el contenido con <code>&lt;h2&gt;</code> para secciones y <code>&lt;h3&gt;</code> para subsecciones.</li>
+  <li>No saltes niveles de encabezado.</li>
+</ul>
+
+<h2>Referenciando el README</h2>
+<ul>
+  <li>Evita duplicar explicaciones largas que ya existen en <code>README.md</code>.</li>
+  <li>Cuando el contenido original permanezca en el README, enlaza usando rutas relativas, por ejemplo <a href="../README.md#installation">Instalación</a>.</li>
+  <li>Pueden incluirse resúmenes cuando sean útiles, pero mantiene el README como la fuente canónica para instrucciones completas.</li>
+</ul>
+
+<h2>Enlaces</h2>
+<ul>
+  <li>Usa enlaces relativos con extensiones explícitas, por ejemplo <a href="./quick_api.html">Quick API</a>.</li>
+  <li>Prefiere <code>./</code> para el mismo directorio y <code>../</code> para directorios padre.</li>
+  <li>Verifica enlaces antes de confirmar usando un comprobador como <code>lychee</code>: <code>lychee docs/**/*.html</code>.</li>
+</ul>
+
+<h2>Lista de migración</h2>
+
+<h3>Destacados</h3>
+<ul>
+  <li>[ ] Crear <code>docs/highlights.html</code>.</li>
+  <li>[ ] Añadir front matter y un único H1.</li>
+  <li>[ ] Resumir beneficios clave en viñetas y enlazar a las páginas de predictores y Quick API.</li>
+</ul>
+
+<h3>Instalación</h3>
+<ul>
+  <li>[x] Crear <a href="./installation.html">installation.html</a>.</li>
+  <li>[x] Detallar instrucciones completas de instalación incluyendo aceleración opcional <code>numba</code>.</li>
+  <li>[x] Referenciar requisitos desde el README para evitar divergencias.</li>
+</ul>
+
+<h3>Reproducibilidad</h3>
+<ul>
+  <li>[ ] Crear <code>docs/reproducibility.html</code>.</li>
+  <li>[ ] Documentar sistema operativo, hardware, versión de Python y pasos para recrear el entorno.</li>
+</ul>
+
+<h3>API rápida</h3>
+<ul>
+  <li>[ ] Crear <code>docs/quick_api.html</code>.</li>
+  <li>[ ] Listar objetos públicos con breves descripciones.</li>
+</ul>
+
+<h3>Tabla de métodos</h3>
+<ul>
+  <li>[ ] Crear <code>docs/method_matrix.html</code>.</li>
+  <li>[ ] Traducir tabla de métodos implementados para cada objeto.</li>
+</ul>
+
+<h3>Experimentos y benchmarks</h3>
+<ul>
+  <li>[x] Crear <a href="./experiments_benchmarks.html">experiments_benchmarks.html</a>.</li>
+  <li>[x] Resumir scripts disponibles y enlazar resultados en <code>benchmark/</code>.</li>
+</ul>
+
+<h3>Parámetros clave</h3>
+<ul>
+  <li>[ ] Crear <code>docs/key_parameters.html</code>.</li>
+  <li>[ ] Describir hiperparámetros ajustables y sus efectos.</li>
+</ul>
+
+<h3>Consejos de rendimiento</h3>
+<ul>
+  <li>[ ] Crear <code>docs/performance_tips.html</code>.</li>
+  <li>[ ] Proporcionar orientación para acelerar cálculos y escalar a altas dimensiones.</li>
+</ul>
+
+<h3>Limitaciones</h3>
+<ul>
+  <li>[x] Crear <code>docs/limitations.html</code>.</li>
+  <li>[x] Aclarar restricciones algorítmicas y prácticas.</li>
+</ul>
+
+<h3>Imágenes</h3>
+<ul>
+  <li>[ ] Crear <code>docs/images.html</code>.</li>
+  <li>[ ] Explicar la omisión de activos binarios y referenciar repositorios externos si es necesario.</li>
+</ul>
+

--- a/docs/experiments_benchmarks_es.html
+++ b/docs/experiments_benchmarks_es.html
@@ -1,15 +1,15 @@
 ---
 layout: default
-title: "Experiments & Benchmarks"
+title: "Experimentos y benchmarks"
 nav_order: 98
 ---
 
 <link rel="stylesheet" href="style.css">
-<div class="lang-switch"><a href="experiments_benchmarks_es.html">ES</a></div>
-<h1>Experiments & Benchmarks</h1>
-<p>This page summarises results from scripts in the <code>benchmark/</code> directory. Each script runs an A/B style comparison with several repetitions and reports the mean runtime, a speedup ratio and any additional metrics specific to the experiment.</p>
+<div class="lang-switch"><a href="experiments_benchmarks.html">EN</a></div>
+<h1>Experimentos y benchmarks</h1>
+<p>Esta página resume resultados de scripts en el directorio <code>benchmark/</code>. Cada script ejecuta una comparación A/B con varias repeticiones y reporta el tiempo medio de ejecución, una razón de aceleración y cualquier métrica adicional específica del experimento.</p>
 <h2>cheche_vs_shushu_ab_test.csv</h2>
-<p>Runtime comparison between CheChe.fit and a ShuShu-style frontier computation (see <code>cheche_vs_shushu_ab_test.py</code> for details).</p>
+<p>Comparación de tiempo de ejecución entre CheChe.fit y un cálculo de frontera al estilo ShuShu (ver <code>cheche_vs_shushu_ab_test.py</code> para detalles).</p>
 <div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>
@@ -29,7 +29,7 @@ nav_order: 98
 </table>
 </div>
 <h2>fit_profile.csv</h2>
-<p>Profiling data for <code>fit</code> performance (script: <code>profile_fit.py</code>).</p>
+<p>Datos de perfilado para el rendimiento de <code>fit</code> (script: <code>profile_fit.py</code>).</p>
 <div class="scroll-table">
 <table border="1" class="dataframe">
   <thead>

--- a/docs/highlights.html
+++ b/docs/highlights.html
@@ -6,6 +6,7 @@ nav_order: 2
 ---
 
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="highlights_es.html">ES</a></div>
 
 <h1>Highlights</h1>
 

--- a/docs/highlights_es.html
+++ b/docs/highlights_es.html
@@ -1,0 +1,24 @@
+---
+layout: default
+title: "Destacados"
+description: "Qué obtienes con SheShe"
+nav_order: 2
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="highlights.html">EN</a></div>
+
+<h1>Destacados</h1>
+
+<h2>Características clave</h2>
+<ul>
+  <li>Descubre clusters guiados por el modelo mediante <a href="modalboundaryclustering_es.html">ModalBoundaryClustering</a>.</li>
+  <li>Funciona para tareas de clasificación y regresión.</li>
+  <li>Explora subespacios y construye conjuntos con <a href="subspacescout_es.html">SubspaceScout</a> y <a href="modalscoutensemble_es.html">ModalScoutEnsemble</a>.</li>
+  <li>Extrae reglas legibles con <a href="regioninterpreter_es.html">RegionInterpreter</a>.</li>
+  <li>Busca máximos locales con el método basado en gradiente <a href="shushu_es.html">ShuShu</a>.</li>
+  <li>Calcula fronteras de decisión 2D con <a href="cheche_es.html">CheChe</a>.</li>
+  <li>Visualiza superficies bidimensionales y 3D con utilidades de graficado incorporadas.</li>
+</ul>
+
+<p>Consulta la <a href="quick_api_es.html">API rápida</a> para una referencia completa de los objetos públicos.</p>
+

--- a/docs/how_it_works.html
+++ b/docs/how_it_works.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 0
 ---
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="how_it_works_es.html">ES</a></div>
 
 <h1>How SheShe Works</h1>
 

--- a/docs/how_it_works_es.html
+++ b/docs/how_it_works_es.html
@@ -1,0 +1,30 @@
+---
+layout: default
+title: "Cómo funciona"
+parent: SheShe
+nav_order: 0
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="how_it_works.html">EN</a></div>
+
+<h1>Cómo funciona SheShe</h1>
+
+<p>SheShe transforma un modelo probabilístico en un explorador de su propio paisaje de decisión. Busca <strong>máximos locales</strong> en la probabilidad por clase o el valor predicho y puede delinear regiones alrededor de los modos descubiertos.</p>
+
+<h2>Fundamento matemático</h2>
+<p>La optimización sigue actualizaciones de ascenso por gradiente <code>x_{k+1} = x_k + α∇f(x_k)</code> hasta que la norma del gradiente cae por debajo de un pequeño <code>ε</code>.</p>
+<p>Los barridos de frontera disparan rayos desde cada pico y localizan puntos de inflexión donde <code>d²f/dr² = 0</code> con un cambio de concavidad, o se alcanza una caída percentil, delimitando regiones alrededor de cada modo. Ver <a href="shushu_es.html">ShuShu</a> y <a href="modalboundaryclustering_es.html">ModalBoundaryClustering</a> para más detalles.</p>
+
+<h2>Componentes</h2>
+
+<h3><a href="modalboundaryclustering_es.html">ModalBoundaryClustering</a></h3>
+<p>Este enfoque de clustering explora superficies de puntuación en busca de modos separados y dibuja fronteras supervisadas alrededor de cada uno. Realiza su propia optimización y no depende de ShuShu ni CheChe.</p>
+
+<h3><a href="shushu_es.html">ShuShu</a></h3>
+<p>ShuShu es un optimizador ligero de ascenso por gradiente que puede sondear cualquier función de puntuación. Localiza máximos locales de forma independiente y puede combinarse con otras herramientas según sea necesario.</p>
+
+<h3><a href="cheche_es.html">CheChe</a></h3>
+<p>CheChe proyecta trayectorias de optimización en dos dimensiones y dibuja fronteras de casco convexo para pares de características seleccionados. Opera por separado de ModalBoundaryClustering y ShuShu para ofrecer análisis visual.</p>
+
+<p>Estos componentes independientes permiten a SheShe revelar la estructura de modelos complejos siguiendo sus picos y mapeando fronteras de la forma que mejor se adapte a la tarea.</p>
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@ has_children: true
 ---
 
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="index_es.html">ES</a></div>
 
 <h1>SheShe</h1>
 

--- a/docs/index_es.html
+++ b/docs/index_es.html
@@ -1,0 +1,72 @@
+---
+layout: default
+title: SheShe
+nav_order: 1
+has_children: true
+---
+
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="index.html">EN</a></div>
+
+<h1>SheShe</h1>
+
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+sh = ModalBoundaryClustering().fit(X, y)
+sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+plt.show()
+</code></pre>
+
+<p>Segmentación Inteligente de Bordes de Alta Dimensión y Explorador de Hiperfronteras</p>
+
+<p>SheShe convierte cualquier modelo probabilístico en un explorador de su propia superficie de decisión. Sigue máximos locales de probabilidad por clase o valor predicho para descubrir regiones nítidas y legibles que respetan la frontera supervisada del problema.</p>
+
+<p>Aprende cómo SheShe explora los máximos locales y cómo sus herramientas operan de forma independiente en <a href="how_it_works_es.html">Cómo funciona</a>.</p>
+
+<h2>Primeros pasos</h2>
+
+<p>Instala la librería y ejecuta las pruebas básicas:</p>
+
+<pre><code class="language-python">pip install sheshe
+PYTHONPATH=src pytest tests/test_basic.py::test_import_and_fit -q
+</code></pre>
+<p>Consulta <a href="./installation_es.html">Instalación</a> para instrucciones completas.</p>
+
+<h2>Consejos de rendimiento</h2>
+<p><a href="performance_tips_es.html">Consejos de rendimiento</a> describe heurísticas y ajustes de parámetros para conjuntos de datos grandes.</p>
+
+<h2>Predictores</h2>
+
+<p>El proyecto expone varios predictores y utilidades. Cada sección a continuación describe uno con más detalle:</p>
+
+<ul>
+  <li><a href="modalboundaryclustering_es.html">ModalBoundaryClustering</a></li>
+  <li><a href="subspacescout_es.html">SubspaceScout</a></li>
+  <li><a href="modalscoutensemble_es.html">ModalScoutEnsemble</a></li>
+  <li><a href="regioninterpreter_es.html">RegionInterpreter</a></li>
+  <li><a href="shushu_es.html">ShuShu</a></li>
+  <li><a href="cheche_es.html">CheChe</a></li>
+  <li><a href="visualization_3d_es.html">Visualización 3D</a></li>
+</ul>
+
+<h2>Experimentos y benchmarks</h2>
+<p>Las comparaciones de rendimiento y resultados de perfilado están disponibles en <a href="experiments_benchmarks_es.html">Experimentos y benchmarks</a>.</p>
+
+<h2>Acerca de</h2>
+
+<p>SheShe es desarrollado por José Carlos Del Valle. Conecta en <a href="https://www.linkedin.com/in/jose-carlos-del-valle/">LinkedIn</a> o explora su <a href="https://jcval94.github.io/Portfolio/">portafolio</a>.</p>
+
+<h2>Contribuir</h2>
+
+<p>Las mejoras son bienvenidas. Haz un fork del repositorio, instala las dependencias de desarrollo y ejecuta las pruebas:</p>
+
+<pre><code class="language-python">pip install -e ".[dev]"
+PYTHONPATH=src pytest -q
+</code></pre>
+
+<p>Liberado bajo la licencia MIT.</p>
+

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -6,6 +6,7 @@ nav_order: 3
 ---
 
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="installation_es.html">ES</a></div>
 
 <h1>Installation</h1>
 

--- a/docs/installation_es.html
+++ b/docs/installation_es.html
@@ -1,0 +1,29 @@
+---
+layout: default
+title: "Instalación"
+description: "Requisitos e instrucciones de configuración para SheShe"
+nav_order: 3
+---
+
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="installation.html">EN</a></div>
+
+<h1>Instalación</h1>
+
+<h2>Requisitos</h2>
+<p>SheShe requiere <strong>Python &gt;=3.9</strong>. Es mejor trabajar dentro de un entorno virtual. Las dependencias base incluyen <code>numpy</code>, <code>pandas</code>, <code>scikit-learn&gt;=1.1</code> y <code>matplotlib</code>. Consulta el <a href="../README_ES.md#instalacion">README</a> para referencia.</p>
+
+<h2>Instalar desde PyPI</h2>
+<p>Instala la última versión desde PyPI:</p>
+<pre><code>pip install sheshe
+</code></pre>
+<p>La aceleración opcional está disponible vía <a href="https://numba.pydata.org/">numba</a>:</p>
+<pre><code>pip install "sheshe[numba]"
+</code></pre>
+
+<h2>Entorno de desarrollo</h2>
+<p>Para contribuir a SheShe, instala en modo editable con dependencias de pruebas y ejecuta la suite:</p>
+<pre><code>pip install -e ".[dev]"
+PYTHONPATH=src pytest -q
+</code></pre>
+

--- a/docs/key_parameters.html
+++ b/docs/key_parameters.html
@@ -6,6 +6,7 @@ nav_order: 7
 ---
 
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="key_parameters_es.html">ES</a></div>
 
 <h1>Key parameters</h1>
 

--- a/docs/key_parameters_es.html
+++ b/docs/key_parameters_es.html
@@ -1,0 +1,62 @@
+---
+layout: default
+title: "Parámetros clave"
+description: "Hiperparámetros importantes y sus efectos"
+nav_order: 7
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="key_parameters.html">EN</a></div>
+
+<h1>Parámetros clave</h1>
+
+<p>Principales hiperparámetros que influyen en la búsqueda y el clustering.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Parámetro</th>
+      <th>Efecto</th>
+      <th>Referencia</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>base_2d_rays</code></td>
+      <td>Controla la resolución angular en 2D (32 por defecto). 3D escala a ~34; dimensiones superiores usan subespacios.</td>
+      <td><a href="modalboundaryclustering_es.html">ModalBoundaryClustering</a></td>
+    </tr>
+    <tr>
+      <td><code>direction</code></td>
+      <td>Selecciona la dirección de escaneo para localizar el punto de inflexión: <code>center_out</code> o <code>outside_in</code>.</td>
+      <td><a href="modalboundaryclustering_es.html">ModalBoundaryClustering</a></td>
+    </tr>
+    <tr>
+      <td><code>scan_radius_factor</code>, <code>scan_steps</code></td>
+      <td>Definen tamaño y resolución del escaneo radial alrededor de los puntos semilla.</td>
+      <td><a href="modalboundaryclustering_es.html">ModalBoundaryClustering</a></td>
+    </tr>
+    <tr>
+      <td><code>optim_method</code></td>
+      <td>Elige entre <code>gradient_ascent</code> (por defecto) o <code>trust_region_newton</code> para la maximización local.</td>
+      <td><a href="shushu_es.html">ShuShu</a></td>
+    </tr>
+    <tr>
+      <td><code>grad_*</code></td>
+      <td>Hiperparámetros para ascenso por gradiente (tasa, iteraciones, tolerancias); usados cuando <code>optim_method="gradient_ascent"</code>.</td>
+      <td><a href="shushu_es.html">ShuShu</a></td>
+    </tr>
+    <tr>
+      <td><code>max_subspaces</code></td>
+      <td>Número máximo de subespacios considerados cuando la dimensionalidad &gt; 3.</td>
+      <td><a href="subspacescout_es.html">SubspaceScout</a></td>
+    </tr>
+    <tr>
+      <td><code>density_alpha</code>, <code>density_k</code></td>
+      <td>Penalización opcional de densidad usando HNSW k‑NN para mantener los centros dentro de la nube de datos; desactiva con <code>density_alpha=0</code>.</td>
+      <td><a href="modalboundaryclustering_es.html">ModalBoundaryClustering</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Los valores por defecto favorecen la velocidad; consulta <a href="highlights_es.html">Destacados</a> para consejos de rendimiento y <a href="limitations_es.html">Limitaciones</a> para restricciones conocidas.</p>
+

--- a/docs/limitations.html
+++ b/docs/limitations.html
@@ -6,6 +6,7 @@ nav_order: 8
 ---
 
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="limitations_es.html">ES</a></div>
 
 <h1>Limitations</h1>
 

--- a/docs/limitations_es.html
+++ b/docs/limitations_es.html
@@ -1,0 +1,30 @@
+---
+layout: default
+title: "Limitaciones"
+description: "Restricciones conocidas y estrategias de mitigación para SheShe"
+nav_order: 8
+---
+
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="limitations.html">EN</a></div>
+
+<h1>Limitaciones</h1>
+
+<p>SheShe proporciona herramientas para análisis modal, pero se aplican varias limitaciones:</p>
+
+<h2>Dependencia de la representación de la superficie</h2>
+<p>Los algoritmos suponen una superficie suave y bien muestreada. Mallas imperfectas o puntos escasos degradan las estimaciones de frontera.</p>
+<p><strong>Mitigación:</strong> preprocesa las mallas para eliminar ruido, interpola regiones faltantes y valida frente a benchmarks conocidos.</p>
+
+<h2>Aproximaciones en alta dimensión</h2>
+<p>En dimensiones muy altas SheShe se basa en aproximaciones que pueden omitir estructuras sutiles y aumentar el tiempo de cómputo.</p>
+<p><strong>Mitigación:</strong> aplica reducción de dimensionalidad o enfócate en subespacios informativos con <a href="./subspacescout_es.html">SubspaceScout</a>.</p>
+
+<h2>Sensibilidad al ruido y muestreo</h2>
+<p>Datos ruidosos o escasamente muestreados pueden producir fronteras inestables.</p>
+<p><strong>Mitigación:</strong> limpia las entradas y agrega múltiples ejecuciones mediante <a href="./modalscoutensemble_es.html">ModalScoutEnsemble</a>.</p>
+
+<h2>Ajuste de parámetros</h2>
+<p>El desempeño depende de elegir anchos de banda y umbrales de clustering adecuados.</p>
+<p><strong>Mitigación:</strong> explora configuraciones mediante la <a href="./quick_api_es.html">API rápida</a> y validación cruzada.</p>
+

--- a/docs/method_matrix_es.html
+++ b/docs/method_matrix_es.html
@@ -1,26 +1,26 @@
 ---
 layout: default
-title: "Method matrix"
-description: "Supported methods across SheShe predictors"
+title: "Matriz de métodos"
+description: "Métodos soportados en los predictores de SheShe"
 nav_order: 6
 ---
 
 <link rel="stylesheet" href="style.css">
-<div class="lang-switch"><a href="method_matrix_es.html">ES</a></div>
+<div class="lang-switch"><a href="method_matrix.html">EN</a></div>
 
-<h1>Method matrix</h1>
+<h1>Matriz de métodos</h1>
 
-<p>This table summarizes which API methods are implemented by each predictor.</p>
+<p>Esta tabla resume qué métodos de la API están implementados por cada predictor.</p>
 
 <table>
   <thead>
     <tr>
-      <th>Method</th>
-      <th><a href="modalboundaryclustering.html">ModalBoundaryClustering</a></th>
-      <th><a href="shushu.html">ShuShu</a></th>
-      <th><a href="cheche.html">CheChe</a></th>
-      <th><a href="modalscoutensemble.html">ModalScoutEnsemble</a></th>
-      <th>Brief description</th>
+      <th>Método</th>
+      <th><a href="modalboundaryclustering_es.html">ModalBoundaryClustering</a></th>
+      <th><a href="shushu_es.html">ShuShu</a></th>
+      <th><a href="cheche_es.html">CheChe</a></th>
+      <th><a href="modalscoutensemble_es.html">ModalScoutEnsemble</a></th>
+      <th>Descripción breve</th>
     </tr>
   </thead>
   <tbody>
@@ -30,7 +30,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Fit the model to the dataset.</td>
+      <td>Ajusta el modelo al conjunto de datos.</td>
     </tr>
     <tr>
       <td><code>fit_predict</code></td>
@@ -38,7 +38,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Train and return assigned labels or regions.</td>
+      <td>Entrena y devuelve las etiquetas o regiones asignadas.</td>
     </tr>
     <tr>
       <td><code>fit_transform</code></td>
@@ -46,7 +46,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Fit and transform data into an internal representation.</td>
+      <td>Ajusta y transforma los datos en una representación interna.</td>
     </tr>
     <tr>
       <td><code>transform</code></td>
@@ -54,7 +54,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Transform new samples according to the trained model.</td>
+      <td>Transforma nuevas muestras según el modelo entrenado.</td>
     </tr>
     <tr>
       <td><code>predict</code></td>
@@ -62,7 +62,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Predict labels or values for new samples.</td>
+      <td>Predice etiquetas o valores para nuevas muestras.</td>
     </tr>
     <tr>
       <td><code>predict_proba</code></td>
@@ -70,7 +70,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Estimate prediction probabilities or confidence.</td>
+      <td>Estima probabilidades de predicción o confianza.</td>
     </tr>
     <tr>
       <td><code>decision_function</code></td>
@@ -78,7 +78,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Return score or distance to the decision boundary.</td>
+      <td>Devuelve puntuación o distancia a la frontera de decisión.</td>
     </tr>
     <tr>
       <td><code>predict_regions</code></td>
@@ -86,7 +86,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Indicate the region or cluster each sample belongs to. Similar to <code>get_cluster</code> in some predictors.</td>
+      <td>Indica la región o cluster al que pertenece cada muestra. Similar a <code>get_cluster</code> en algunos predictores.</td>
     </tr>
     <tr>
       <td><code>score</code></td>
@@ -94,7 +94,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Compute a performance metric on test data.</td>
+      <td>Calcula una métrica de desempeño en datos de prueba.</td>
     </tr>
     <tr>
       <td><code>save</code></td>
@@ -102,7 +102,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Save the trained model to disk.</td>
+      <td>Guarda el modelo entrenado en disco.</td>
     </tr>
     <tr>
       <td><code>load</code></td>
@@ -110,7 +110,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Load a previously saved model.</td>
+      <td>Carga un modelo previamente guardado.</td>
     </tr>
     <tr>
       <td><code>plot_pairs</code></td>
@@ -118,7 +118,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Plot feature pairs with regions or clusters.</td>
+      <td>Grafica pares de características con regiones o clusters.</td>
     </tr>
     <tr>
       <td><code>plot_pair_3d</code></td>
@@ -126,7 +126,7 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Plot two features and the response in 3D.</td>
+      <td>Grafica dos características y la respuesta en 3D.</td>
     </tr>
     <tr>
       <td><code>interpretability_summary</code></td>
@@ -134,10 +134,10 @@ nav_order: 6
       <td>✓</td>
       <td>✓</td>
       <td>✓</td>
-      <td>Interpretability summary of regions or the model.</td>
+      <td>Resumen de interpretabilidad de las regiones o del modelo.</td>
     </tr>
   </tbody>
 </table>
 
-<p>See the <a href="../README.md#method-matrix">README</a> for more context.</p>
+<p>Consulta el <a href="../README_ES.md#matriz-de-metodos">README</a> para más contexto.</p>
 

--- a/docs/modalboundaryclustering_es.html
+++ b/docs/modalboundaryclustering_es.html
@@ -5,7 +5,7 @@ parent: SheShe
 nav_order: 1
 ---
 <link rel="stylesheet" href="style.css">
-<div class="lang-switch"><a href="modalboundaryclustering_es.html">ES</a></div>
+<div class="lang-switch"><a href="modalboundaryclustering.html">EN</a></div>
 
 <h1>ModalBoundaryClustering</h1>
 
@@ -19,14 +19,13 @@ sh = ModalBoundaryClustering().fit(X, y)
 sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0])
 plt.show()
 </code></pre>
-<p>Learns regions of high probability or predicted value by climbing local maxima of a</p>
-<p>base estimator. Radial scans trace boundary surfaces around each mode and</p>
-<p>gradient ascent refines the centres, enabling both classification and regression</p>
-<p>workflows.</p>
+<p>Aprende regiones de alta probabilidad o valor predicho escalando los máximos locales de un estimador base.</p>
+<p>Exploraciones radiales trazan superficies de frontera alrededor de cada modo y</p>
+<p>el ascenso por gradiente refina los centros, habilitando flujos tanto de clasificación como de regresión.</p>
 <h2>Mathematical formulation</h2>
-<p>Centres are refined with gradient ascent updates <code>x_{k+1} = x_k + α∇f(x_k)</code> until <code>‖∇f(x_k)‖ &lt; grad_tol</code>.</p>
-<p>From each centre, radial scans sample scores <code>f(x_k + r u)</code> along directions <code>u</code>. Scans stop when <code>∂f/∂r = 0</code>, indicating a stationary point; an inflection point additionally requires <code>d²f/dr² = 0</code> with a sign change, or when the score falls past a percentile or drop fraction of the peak.</p>
-<p>These radii approximate a probability surface from which boundary polygons are built.</p>
+<p>Los centros se refinan con actualizaciones de ascenso por gradiente <code>x_{k+1} = x_k + α∇f(x_k)</code> hasta que <code>‖∇f(x_k)‖ &lt; grad_tol</code>.</p>
+<p>Desde cada centro, exploraciones radiales muestrean puntuaciones <code>f(x_k + r u)</code> a lo largo de direcciones <code>u</code>. Las exploraciones se detienen cuando <code>∂f/∂r = 0</code>, señalando un punto estacionario; un punto de inflexión además requiere <code>d²f/dr² = 0</code> con cambio de signo, o cuando la puntuación cae más allá de un percentil o fracción del pico.</p>
+<p>Estos radios aproximan una superficie de probabilidad de la cual se construyen polígonos de frontera.</p>
 <h2>Example</h2>
 <pre><code class="language-python">
 from sheshe import ModalBoundaryClustering
@@ -35,7 +34,7 @@ mbc.fit(X, y)
 labels = mbc.predict(X)
 </code></pre>
 
-<h2>Usage examples</h2>
+<h2>Ejemplos de uso</h2>
 <pre><code class="language-python">
 from sheshe import ModalBoundaryClustering
 
@@ -52,7 +51,7 @@ mbc.fit(X, y).score(X, y)          # score
 mbc.fit(X, y).save("mbc.joblib")   # save
 ModalBoundaryClustering.load("mbc.joblib")
 </code></pre>
-<h2>Additional examples</h2>
+<h2>Ejemplos adicionales</h2>
 <pre><code class="language-python">
 from sklearn.datasets import load_iris
 from sheshe import ModalBoundaryClustering

--- a/docs/modalscoutensemble.html
+++ b/docs/modalscoutensemble.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 3
 ---
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="modalscoutensemble_es.html">ES</a></div>
 
 <h1>ModalScoutEnsemble</h1>
 

--- a/docs/modalscoutensemble_es.html
+++ b/docs/modalscoutensemble_es.html
@@ -1,0 +1,115 @@
+---
+layout: default
+title: ModalScoutEnsemble
+parent: SheShe
+nav_order: 3
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="modalscoutensemble.html">EN</a></div>
+
+<h1>ModalScoutEnsemble</h1>
+
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ModalScoutEnsemble
+
+X, y = load_iris(return_X_y=True)
+mse = ModalScoutEnsemble().fit(X, y)
+mse.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+plt.show()
+</code></pre>
+<p>Ensamble que aplica <code>ModalBoundaryClustering</code> en los subespacios más prometedores descubiertos por <code>SubspaceScout</code>. Cada submodelo se pondera por puntuación del scout, validación cruzada e importancia de características, y el ensamble puede delegar la optimización a <code>ShuShu</code> cuando <code>ensemble_method="shushu"</code>.</p>
+
+<h2>Ejemplo</h2>
+<pre><code class="language-python">
+from sheshe import ModalScoutEnsemble
+from sklearn.linear_model import LogisticRegression
+mse = ModalScoutEnsemble(base_estimator=LogisticRegression())
+mse.fit(X, y)
+labels = mse.predict(X)
+</code></pre>
+
+<h2>Ejemplos de uso</h2>
+<pre><code class="language-python">
+from sheshe import ModalScoutEnsemble
+from sklearn.linear_model import LogisticRegression
+
+mse = ModalScoutEnsemble(base_estimator=LogisticRegression(), random_state=0)
+mse.fit(X, y)                      # fit
+mse.fit_predict(X, y)              # fit_predict
+mse.fit_transform(X, y)            # fit_transform
+mse.fit(X, y).transform(X)         # transform
+mse.fit(X, y).predict(X)           # predict
+mse.fit(X, y).predict_proba(X)     # predict_proba
+mse.fit(X, y).decision_function(X) # decision_function
+mse.fit(X, y).predict_regions(X)   # predict_regions
+mse.fit(X, y).score(X, y)          # score
+mse.fit(X, y).save("mse.joblib")   # save
+ModalScoutEnsemble.load("mse.joblib")
+</code></pre>
+
+<h2>Ejemplos adicionales</h2>
+<pre><code class="language-python">
+from sheshe import ModalScoutEnsemble
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+mse = ModalScoutEnsemble(
+    base_estimator=LogisticRegression(max_iter=200),
+    task="classification",
+    random_state=0,
+    scout_kwargs={"max_order": 2, "top_m": 4, "sample_size": None},
+    cv=2,
+    # ensemble_method="shushu" usaría el optimizador ShuShu
+)
+mse.fit(X, y)
+print(mse.predict(X[:5]))
+print(mse.predict_proba(X[:5]))
+</code></pre>
+
+<h2>Parámetros</h2>
+<ul>
+<li><code>base_estimator</code> (<code>BaseEstimator</code>): modelo usado para calcular probabilidades o predicciones en cada subespacio.</li>
+<li><code>task</code> (<code>str</code>, opcional): "classification" o "regression". Se infiere del estimador base si es <code>None</code>.</li>
+<li><code>ensemble_method</code> (<code>str</code>, por defecto <code>"modal_scout"</code>): <code>"modal_scout"</code> para usar el ensamble interno de subespacios o <code>"shushu"</code> para delegar en <code>ShuShu</code>.</li>
+<li><code>top_k</code> (<code>int</code>, por defecto <code>8</code>): número máximo de subespacios conservados.</li>
+<li><code>min_score</code> (<code>float</code> o <code>None</code>): puntuación mínima requerida para que un subespacio sea usado.</li>
+<li><code>max_order</code> (<code>int</code> o <code>None</code>): orden máximo de subespacios evaluados.</li>
+<li><code>metric</code> (<code>str</code> o <code>None</code>, por defecto <code>"mi_synergy"</code>): criterio usado para ordenar subespacios.</li>
+<li><code>jaccard_threshold</code> (<code>float</code>, por defecto <code>0.55</code>): similitud de Jaccard mínima para considerar dos subespacios redundantes.</li>
+<li><code>alpha</code> (<code>float</code>, por defecto <code>0.5</code>): exponente para la puntuación del scout en el peso final.</li>
+<li><code>beta</code> (<code>float</code>, por defecto <code>0.5</code>): exponente para el desempeño de validación cruzada.</li>
+<li><code>gamma</code> (<code>float</code>, por defecto <code>0.5</code>): exponente para la importancia global de características.</li>
+<li><code>cv</code> (<code>int</code> o <code>None</code>, por defecto <code>3</code>): número de folds de CV; <code>0</code> o <code>None</code> usa una división holdout.</li>
+<li><code>cv_metric_cls</code> (<code>Callable</code>, por defecto <code>balanced_accuracy_score</code>): métrica para CV de clasificación.</li>
+<li><code>cv_metric_reg</code> (<code>Callable</code>, por defecto <code>r2_score</code>): métrica para CV de regresión.</li>
+<li><code>cv_floor</code> (<code>float</code> o <code>None</code>): descarta subespacios con CV por debajo de este valor.</li>
+<li><code>n_jobs</code> (<code>int</code>, por defecto <code>1</code>): número de trabajos paralelos para CV.</li>
+<li><code>random_state</code> (<code>int</code> o <code>None</code>, por defecto <code>0</code>): semilla RNG.</li>
+<li><code>base_2d_rays</code> (<code>int</code>, por defecto <code>8</code>): número base de rayos para ajustes MBC en cada subespacio.</li>
+<li><code>ray_cap</code> (<code>int</code>, por defecto <code>48</code>): rayos máximos permitidos por subespacio.</li>
+<li><code>time_budget_s</code> (<code>float</code> o <code>None</code>): presupuesto de tiempo global opcional para el ajuste.</li>
+<li><code>use_importances</code> (<code>bool</code>, por defecto <code>True</code>): incluir importancias de características globales en el peso.</li>
+<li><code>importance_sample_size</code> (<code>int</code> o <code>None</code>, por defecto <code>4096</code>): tamaño de muestra para calcular importancias globales.</li>
+<li><code>scout_kwargs</code> (<code>dict</code> o <code>None</code>): parámetros enviados a <code>SubspaceScout</code>.</li>
+<li><code>shushu_kwargs</code> (<code>dict</code> o <code>None</code>): parámetros enviados a <code>ShuShu</code> cuando <code>ensemble_method="shushu"</code>.</li>
+<li><code>mbc_kwargs</code> (<code>dict</code> o <code>None</code>): argumentos adicionales pasados a cada instancia de <code>ModalBoundaryClustering</code>.</li>
+<li><code>verbose</code> (<code>int</code>, por defecto <code>0</code>): nivel de registro.</li>
+<li><code>prediction_within_region</code> (<code>bool</code>, por defecto <code>False</code>): evalúa el estimador base solo dentro de cada región durante la predicción.</li>
+</ul>
+
+<h2>Métodos</h2>
+<ul>
+<li><code>fit(X, y)</code> – entrena el ensamble en <code>X</code> e <code>y</code>.</li>
+<li><code>predict(X)</code> – predice etiquetas o ids de cluster.</li>
+<li><code>predict_proba(X)</code> – probabilidades de clase agregadas a través de subespacios.</li>
+<li><code>decision_function(X)</code> – puntuaciones de decisión promediadas entre submodelos.</li>
+<li><code>predict_regions(X)</code> – DataFrame con asignaciones de región.</li>
+<li><code>plot_pairs(X, y=None, show_histograms=False, **kwargs)</code> – delega en <code>ModalBoundaryClustering.plot_pairs</code> para un submodelo seleccionado, incluyendo histogramas marginales opcionales.</li>
+<li><code>plot_pair_3d(X, pair, **kwargs)</code> – superficie 3D para un par de características de un submodelo.</li>
+</ul>
+

--- a/docs/performance_tips.html
+++ b/docs/performance_tips.html
@@ -6,6 +6,7 @@ nav_order: 9
 ---
 
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="performance_tips_es.html">ES</a></div>
 
 <h1>Performance Tips</h1>
 

--- a/docs/performance_tips_es.html
+++ b/docs/performance_tips_es.html
@@ -1,0 +1,30 @@
+---
+layout: default
+title: "Consejos de rendimiento"
+description: "Heurísticas y ajustes para una exploración más rápida"
+nav_order: 9
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="performance_tips.html">EN</a></div>
+
+<h1>Consejos de rendimiento</h1>
+
+<h2>Heurísticas</h2>
+<p>SheShe aplica reglas simples para mantener los tiempos de ejecución manejables. La principal es <code>auto_rays_by_dim</code>, que limita <code>base_2d_rays</code> a medida que crece la dimensionalidad:</p>
+<ul>
+  <li>2–24 características → usa el valor completo de <code>base_2d_rays</code> (32 por defecto).</li>
+  <li>25–64 características → limita <code>base_2d_rays</code> a 16.</li>
+  <li>65+ características → limita <code>base_2d_rays</code> a 12.</li>
+</ul>
+<p>Desactiva este comportamiento con <code>auto_rays_by_dim=False</code> para mantener el número original de rayos.</p>
+
+<h2>Conjuntos de datos de alta dimensión</h2>
+<p>Los espacios de características grandes requieren cuidado adicional. Considera los siguientes ajustes al trabajar con decenas o cientos de dimensiones:</p>
+<ul>
+  <li><strong>Reduce rayos</strong>: establece <code>base_2d_rays</code> en 16 o 12 cuando <code>auto_rays_by_dim</code> esté desactivado o se necesite un límite más bajo.</li>
+  <li><strong>Recorta pasos de exploración</strong>: baja <code>scan_steps</code> de 24 a 12 para reducir a la mitad las evaluaciones a lo largo de cada rayo.</li>
+  <li><strong>Limita la exploración</strong>: disminuye <code>n_max_seeds</code> y <code>max_subspaces</code> para restringir el número de puntos iniciales y subespacios escaneados.</li>
+  <li><strong>Preselecciona subespacios</strong>: ejecuta <a href="subspacescout_es.html">SubspaceScout</a> para enfocarte en pares de características prometedores antes de lanzar búsquedas más pesadas.</li>
+</ul>
+<p>Consulta el <a href="../README_ES.md#consejos-de-rendimiento">README</a> para contexto adicional sobre cómo interactúan estos parámetros.</p>
+

--- a/docs/quick_api.html
+++ b/docs/quick_api.html
@@ -6,6 +6,7 @@ nav_order: 5
 ---
 
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="quick_api_es.html">ES</a></div>
 
 <h1>Quick API</h1>
 

--- a/docs/quick_api_es.html
+++ b/docs/quick_api_es.html
@@ -1,0 +1,78 @@
+---
+layout: default
+title: "API rápida"
+description: "Objetos públicos expuestos por el paquete SheShe"
+nav_order: 5
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="quick_api.html">EN</a></div>
+
+<h1>API rápida</h1>
+
+<p>Los siguientes objetos están disponibles para importar:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Submódulo</th>
+      <th>Objeto</th>
+      <th>Sentencia de importación</th>
+      <th>Descripción</th>
+      <th>Docs</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>cheche</code></td>
+      <td><code>CheChe</code></td>
+      <td><code>from sheshe import CheChe</code></td>
+      <td>Calcula fronteras 2D en pares de características seleccionados.</td>
+      <td><a href="cheche_es.html">cheche_es.html</a></td>
+    </tr>
+    <tr>
+      <td><code>sheshe</code></td>
+      <td><code>ClusterRegion</code></td>
+      <td><code>from sheshe import ClusterRegion</code></td>
+      <td>Dataclass que describe una región descubierta.</td>
+      <td>&mdash;</td>
+    </tr>
+    <tr>
+      <td><code>sheshe</code></td>
+      <td><code>ModalBoundaryClustering</code></td>
+      <td><code>from sheshe import ModalBoundaryClustering</code></td>
+      <td>Clustering supervisado guiado por probabilidades o predicciones del modelo.</td>
+      <td><a href="modalboundaryclustering_es.html">modalboundaryclustering_es.html</a></td>
+    </tr>
+    <tr>
+      <td><code>modal_scout_ensemble</code></td>
+      <td><code>ModalScoutEnsemble</code></td>
+      <td><code>from sheshe import ModalScoutEnsemble</code></td>
+      <td>Explora subespacios con conjuntos de scouts.</td>
+      <td><a href="modalscoutensemble_es.html">modalscoutensemble_es.html</a></td>
+    </tr>
+    <tr>
+      <td><code>region_interpretability</code></td>
+      <td><code>RegionInterpreter</code></td>
+      <td><code>from sheshe import RegionInterpreter</code></td>
+      <td>Convierte objetos <code>ClusterRegion</code> en reglas legibles.</td>
+      <td><a href="regioninterpreter_es.html">regioninterpreter_es.html</a></td>
+    </tr>
+    <tr>
+      <td><code>shushu</code></td>
+      <td><code>ShuShu</code></td>
+      <td><code>from sheshe import ShuShu</code></td>
+      <td>Búsqueda basada en gradiente de máximos locales.</td>
+      <td><a href="shushu_es.html">shushu_es.html</a></td>
+    </tr>
+    <tr>
+      <td><code>subspace_scout</code></td>
+      <td><code>SubspaceScout</code></td>
+      <td><code>from sheshe import SubspaceScout</code></td>
+      <td>Explora subespacios para iniciar el descubrimiento de regiones.</td>
+      <td><a href="subspacescout_es.html">subspacescout_es.html</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Ejemplos de uso detallados permanecen en el <a href="../README_ES.md#quick-api">README</a>.</p>
+

--- a/docs/regioninterpreter.html
+++ b/docs/regioninterpreter.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 4
 ---
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="regioninterpreter_es.html">ES</a></div>
 
 <h1>RegionInterpreter</h1>
 

--- a/docs/regioninterpreter_es.html
+++ b/docs/regioninterpreter_es.html
@@ -1,0 +1,77 @@
+---
+layout: default
+title: RegionInterpreter
+parent: SheShe
+nav_order: 4
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="regioninterpreter.html">EN</a></div>
+
+<h1>RegionInterpreter</h1>
+
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering, RegionInterpreter
+
+iris = load_iris()
+X, y = iris.data, iris.target
+sh = ModalBoundaryClustering().fit(X, y)
+cards = RegionInterpreter(feature_names=iris.feature_names).summarize(sh.regions_)
+sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+plt.show()
+</code></pre>
+<p>Convierte objetos <code>ClusterRegion</code> en conjuntos de reglas compactos y legibles. Resume cada región con cajas alineadas a los ejes, destaca proyecciones informativas y ofrece utilidades como <code>pretty_print</code> para reportes. Backends opcionales de LLM pueden transformar los resúmenes en descripciones en lenguaje natural.</p>
+
+<h2>Formulación matemática</h2>
+<p>Para cada característica <code>j</code>, una regla alineada al eje usa cuantiles <code>[Q_q(x_j), Q_{1-q}(x_j)]</code>, capturando aproximadamente <code>1-2q</code> de los datos.</p>
+<p>Los radios limitados se marcan usando el z-score <code>z=(r-μ)/σ</code> cuando <code>|z| &gt; cap_threshold</code>.</p>
+<p><strong>Ejemplo:</strong> con <code>q_box=0.05</code> y valores 1‑10, la regla es <code>[1.45, 9.55]</code>. Un radio 3 con media 2 y <code>σ=0.3</code> da <code>z≈3.3</code>.</p>
+
+<h2>Ejemplo</h2>
+<pre><code class="language-python">
+from sheshe import RegionInterpreter
+ri = RegionInterpreter(feature_names=["sepal", "petal"])
+summary = ri.summarize(region)
+</code></pre>
+
+<h2>Ejemplos de uso</h2>
+<pre><code class="language-python">
+from sheshe import RegionInterpreter
+
+ri = RegionInterpreter(feature_names=["sepal", "petal"])
+ri.summarize(region)       # resumir una región
+ri.summarize([region])     # resumir una lista de regiones
+</code></pre>
+
+<h2>Ejemplos adicionales</h2>
+<pre><code class="language-python">
+from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering, RegionInterpreter
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+sh = ModalBoundaryClustering().fit(X, y)
+cards = RegionInterpreter(feature_names=iris.feature_names).summarize(sh.regions_)
+RegionInterpreter.pretty_print(cards[:1])
+</code></pre>
+
+<h2>Parámetros</h2>
+<ul>
+<li><code>feature_names</code> (<code>list[str]</code> o <code>None</code>, por defecto <code>None</code>): nombres para cada característica usada en las reglas generadas.</li>
+<li><code>q_box</code> (<code>float</code>, por defecto <code>0.05</code>): cuantil usado para calcular cajas robustas alineadas a los ejes.</li>
+<li><code>k_pairs</code> (<code>int</code>, por defecto <code>2</code>): número de proyecciones 2D informativas a incluir.</li>
+<li><code>decimals</code> (<code>int</code>, por defecto <code>2</code>): precisión decimal en las reglas emitidas.</li>
+<li><code>cap_threshold</code> (<code>float</code>, por defecto <code>6.393</code>): umbral z-score para marcar radios limitados.</li>
+<li><code>near_const_tol</code> (<code>float</code>, por defecto <code>0.12</code>): tolerancia para reportar dimensiones casi constantes.</li>
+<li><code>inverse_transform</code> (callable, opcional): función aplicada a los puntos antes de la extracción de reglas (por ejemplo, desescalado).</li>
+<li><code>feature_bounds</code> (<code>Sequence[Tuple[float, float]]</code> o <code>None</code>): límites estrictos para cada característica para recortar cajas.</li>
+<li><code>include_center_in_box</code> (<code>bool</code>, por defecto <code>True</code>): incluye el centro de la región al calcular cajas alineadas.</li>
+</ul>
+
+<h2>Métodos</h2>
+<ul>
+<li><code>summarize(regions)</code> – devuelve una lista de diccionarios con encabezados, reglas alineadas a ejes y proyecciones de pares para las regiones proporcionadas.</li>
+</ul>
+

--- a/docs/reproducibility.html
+++ b/docs/reproducibility.html
@@ -6,6 +6,7 @@ nav_order: 4
 ---
 
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="reproducibility_es.html">ES</a></div>
 
 <h1>Reproducibility</h1>
 

--- a/docs/reproducibility_es.html
+++ b/docs/reproducibility_es.html
@@ -1,0 +1,63 @@
+---
+layout: default
+title: "Reproducibilidad"
+description: "Pasos para recrear el entorno de SheShe"
+nav_order: 4
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="reproducibility.html">EN</a></div>
+
+<h1>Reproducibilidad</h1>
+
+<h2>Sistema de referencia</h2>
+<ul>
+  <li><strong>SO:</strong> Ubuntu 24.04.2 LTS</li>
+  <li><strong>CPU:</strong> Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz</li>
+  <li><strong>GPU:</strong> Ninguna</li>
+  <li><strong>Python:</strong> 3.12.10</li>
+ </ul>
+
+<h2>Configuración del entorno</h2>
+<ol>
+  <li>Crear y activar un entorno virtual:
+<pre><code class="language-python">python -m venv .venv
+source .venv/bin/activate</code></pre>
+  </li>
+  <li>Instalar dependencias de desarrollo y ejecutar pruebas para verificar:
+<pre><code class="language-python">pip install -e ".[dev]"
+PYTHONPATH=src pytest -q</code></pre>
+  </li>
+</ol>
+
+<h2>Semillas aleatorias</h2>
+<p>Todos los estimadores de SheShe aceptan un argumento <code>random_state</code> para asegurar resultados deterministas:</p>
+<pre><code class="language-python">from sheshe import ModalBoundaryClustering
+clustering = ModalBoundaryClustering(random_state=0)</code></pre>
+<p>Fija el mismo <code>random_state</code> en ejecuciones distintas para reproducir experimentos.</p>
+
+<h2>Exportar información del sistema</h2>
+<p>Captura versiones exactas de paquetes y detalles de la plataforma para referencia futura:</p>
+<pre><code class="language-python">python -m pip freeze > packages.txt
+python - <<'PY'
+import json, platform, sys
+info = {
+    "platform": platform.platform(),
+    "python": sys.version,
+}
+print(json.dumps(info, indent=2))
+PY
+</code></pre>
+
+<h2>Cómo reportar diferencias</h2>
+<p>Si los resultados difieren de los benchmarks publicados:</p>
+<ul>
+  <li>Comparte el <code>packages.txt</code> generado y el JSON de plataforma.</li>
+  <li>Describe el conjunto de datos y parámetros usados, incluyendo valores de <code>random_state</code>.</li>
+  <li>Abre un issue con registros y pasos de reproducción.</li>
+</ul>
+
+<h2>TODO</h2>
+<ul>
+  <li>Especificar capacidad de RAM recomendada.</li>
+</ul>
+

--- a/docs/shushu.html
+++ b/docs/shushu.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 5
 ---
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="shushu_es.html">ES</a></div>
 
 <h1>ShuShu</h1>
 

--- a/docs/shushu_es.html
+++ b/docs/shushu_es.html
@@ -1,0 +1,96 @@
+---
+layout: default
+title: ShuShu
+parent: SheShe
+nav_order: 5
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="shushu.html">EN</a></div>
+
+<h1>ShuShu</h1>
+
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import ShuShu
+
+X, y = load_iris(return_X_y=True)
+sh = ShuShu().fit(X, y)
+sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+plt.show()
+</code></pre>
+<p>Optimizador basado en gradiente que busca máximos locales de una puntuación escalar o probabilidades de clase. Ejecuta una optimización por clase cuando se proporcionan etiquetas y también puede operar sobre funciones de puntuación definidas por el usuario, devolviendo centroides de cada modo descubierto.</p>
+
+<h2>Formulación matemática</h2>
+<p>ShuShu realiza actualizaciones de ascenso por gradiente <code>x_{t+1} = x_t + η∇f(x_t)</code> hasta que <code>‖∇f(x_t)‖ &lt; tol</code> o se alcanza un número máximo de iteraciones.</p>
+<p>Cuando no hay gradientes analíticos, los estima mediante SPSA: <code>∂f/∂x_i ≈ (f(x + cΔ) - f(x - cΔ))/(2cΔ_i)</code> con perturbaciones de Rademacher <code>Δ_i ∈ {−1,1}</code>.</p>
+
+<h2>Ejemplo</h2>
+<pre><code class="language-python">
+from sheshe import ShuShu
+ss = ShuShu()
+ss.fit(X, y)
+labels = ss.predict(X)
+</code></pre>
+
+<h2>Ejemplos de uso</h2>
+<pre><code class="language-python">
+from sheshe import ShuShu
+
+shu = ShuShu(random_state=0)
+shu.fit(X, y)                      # fit
+shu.fit_predict(X, y)              # fit_predict
+shu.fit_transform(X, y)            # fit_transform
+shu.fit(X, y).transform(X)         # transform
+shu.fit(X, y).predict(X)           # predict
+shu.fit(X, y).predict_proba(X)     # predict_proba
+shu.fit(X, y).decision_function(X) # decision_function
+shu.fit(X, y).predict_regions(X)   # predict_regions
+shu.fit(X, y).score(X, y)          # score
+shu.fit(X, y).save("shu.joblib")   # save
+ShuShu.load("shu.joblib")
+</code></pre>
+
+<h2>Ejemplos adicionales</h2>
+<pre><code class="language-python">
+from sklearn.datasets import load_iris
+from sheshe import ShuShu
+
+X, y = load_iris(return_X_y=True)
+sh = ShuShu(random_state=0).fit(X, y)
+print(sh.summary_tables()[0][["class_label", "n_clusters"]])
+
+import numpy as np
+def paraboloid(Z):
+    return -np.linalg.norm(Z - 1.0, axis=1)
+
+sc = ShuShu(random_state=0).fit(np.random.rand(100, 2), score_fn=paraboloid)
+print(sc.centroids_)
+
+from sklearn.linear_model import LogisticRegression
+model = LogisticRegression(max_iter=200).fit(X, y)
+ShuShu(random_state=0).fit(X, y, score_model=model)
+</code></pre>
+
+<h2>Parámetros</h2>
+<ul>
+<li><code>clusterer_factory</code> (callable o <code>None</code>, por defecto <code>None</code>): fábrica que devuelve el optimizador interno. Cuando es <code>None</code> se usa una implementación por defecto.</li>
+<li><code>random_state</code> (<code>int</code> o <code>None</code>, por defecto <code>None</code>): semilla para reproducibilidad.</li>
+<li><code>**clusterer_kwargs</code> – argumentos adicionales enviados al optimizador interno.</li>
+</ul>
+
+<h2>Métodos</h2>
+<ul>
+<li><code>fit(X, y=None, score_fn=None, ...)</code> – entrena el optimizador. Cuando se proporciona <code>y</code>, la función de puntuación se aprende por clase; de lo contrario debe proporcionarse <code>score_fn</code>.</li>
+<li><code>fit_predict(X, y=None, **kwargs)</code> – envoltorio de conveniencia que llama a <code>fit</code> y luego <code>predict</code>.</li>
+<li><code>predict(X)</code> – devuelve etiquetas de clase o ids de cluster.</li>
+<li><code>predict_proba(X)</code> – probabilidades de clase (tras entrenar con etiquetas).</li>
+<li><code>decision_function(X)</code> – puntuaciones de decisión en bruto.</li>
+<li><code>transform(X)</code> – matriz de pertenencia/afinidad.</li>
+<li><code>fit_transform(X, y=None, **kwargs)</code> – combina <code>fit</code> y <code>transform</code>.</li>
+<li><code>plot_pairs(X, y=None, max_pairs=None, show_histograms=False)</code> – gráficos de dispersión para pares de características con histogramas marginales opcionales.</li>
+<li><code>plot_classes(X, y, grid_res=200, contour_levels=None, max_paths=20, show_paths=True)</code> – visualiza superficies de puntuación por clase.</li>
+<li><code>plot_pair_3d(X, y=None, features=(i, j), ax=None, fig=None, grid=64)</code> – renderizado 3D de la función de puntuación.</li>
+<li><code>get_cluster(cluster_id, with_geometry=False)</code> – recupera información sobre un cluster descubierto.</li>
+</ul>
+

--- a/docs/style.css
+++ b/docs/style.css
@@ -72,3 +72,24 @@
   overflow-y: auto;
   margin-bottom: 1.5rem;
 }
+
+/* Language switch button */
+.lang-switch {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1000;
+}
+
+.lang-switch a {
+  background: var(--primary-color);
+  color: #fff;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.lang-switch a:hover {
+  background: var(--accent-color);
+}

--- a/docs/subspacescout.html
+++ b/docs/subspacescout.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 2
 ---
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="subspacescout_es.html">ES</a></div>
 
 <h1>SubspaceScout</h1>
 

--- a/docs/subspacescout_es.html
+++ b/docs/subspacescout_es.html
@@ -1,0 +1,95 @@
+---
+layout: default
+title: SubspaceScout
+parent: SheShe
+nav_order: 2
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="subspacescout.html">EN</a></div>
+
+<h1>SubspaceScout</h1>
+
+<pre><code>
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_iris
+from sheshe import SubspaceScout, ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+scout = SubspaceScout().fit(X, y)
+pair = scout.results_[0]["features"]
+ModalBoundaryClustering().fit(X, y).plot_pairs(X, y, pairs=[pair], show_histograms=True)
+plt.show()
+</code></pre>
+<p>Identifica subconjuntos de características informativos para que <code>ModalBoundaryClustering</code> se ejecute solo donde importa en espacios de alta dimensión. Usa información mutua u opcionalmente calificadores basados en modelos para clasificar interacciones y emplea búsqueda en haz para enumerar subespacios prometedores.</p>
+
+<h2>Formulación matemática</h2>
+<p>La información mutua entre un subconjunto <code>X</code> y el objetivo <code>Y</code> es <code>I(X;Y)=∑_{x,y} p(x,y) log(p(x,y)/(p(x)p(y)))</code>.</p>
+<p>El objetivo de sinergia para un conjunto <code>S</code> es <code>Synergy(S) = I(S;Y) - ∑_{i∈S} I(X_i;Y)</code>, capturando información más allá de las características individuales.</p>
+<p>La búsqueda en haz crece subespacios orden por orden y retiene aquellos con mayores puntuaciones.</p>
+
+<h2>Ejemplo</h2>
+<pre><code class="language-python">
+from sheshe import SubspaceScout
+scout = SubspaceScout()
+scout.fit(X, y)
+subspaces = scout.results_
+</code></pre>
+
+<h2>Ejemplos de uso</h2>
+<pre><code class="language-python">
+from sheshe import SubspaceScout
+
+scout = SubspaceScout(random_state=0)
+scout.fit(X, y)          # fit
+results = scout.results_ # access discovered subspaces
+</code></pre>
+
+<h2>Ejemplos adicionales</h2>
+<pre><code class="language-python">
+from sheshe import SubspaceScout
+
+scout = SubspaceScout(
+    # model_method='lightgbm',  # por defecto usa información mutua
+    max_order=4,
+    top_m=50,
+    base_pairs_limit=12,
+    beam_width=10,
+    extend_candidate_pool=16,
+    branch_per_parent=4,
+    marginal_gain_min=1e-3,
+    max_eval_per_order=150,
+    sample_size=4096,
+    time_budget_s=None,
+    task='classification',
+    random_state=0,
+)
+subspaces = scout.fit(X, y)
+</code></pre>
+
+<h2>Parámetros</h2>
+<ul>
+<li><code>model_method</code> (<code>None</code> o <code>"lightgbm"</code> o <code>"ebm"</code>, por defecto <code>None</code>): modelo usado para puntuar subespacios. <code>None</code> usa información mutua.</li>
+<li><code>max_order</code> (<code>int</code>, por defecto <code>3</code>): tamaño máximo de combinaciones de características a explorar.</li>
+<li><code>n_bins</code> (<code>int</code>, por defecto <code>8</code>): número de bins para discretizar características.</li>
+<li><code>top_m</code> (<code>int</code>, por defecto <code>20</code>): número de características preseleccionadas por información mutua individual.</li>
+<li><code>branch_per_parent</code> (<code>int</code>, por defecto <code>5</code>): máximo de extensiones generadas por subespacio padre.</li>
+<li><code>density_occup_min</code> (<code>float</code>, por defecto <code>0.03</code>): ocupación mínima para que un subespacio sea válido.</li>
+<li><code>min_support</code> (<code>int</code>, por defecto <code>30</code>): número mínimo de muestras requerido en un subespacio.</li>
+<li><code>sample_size</code> (<code>int</code> o <code>None</code>, por defecto <code>4096</code>): tamaño de muestra opcional para acelerar cálculos.</li>
+<li><code>task</code> (<code>"classification"</code> o <code>"regression"</code>, por defecto <code>"classification"</code>): tipo de tarea.</li>
+<li><code>random_state</code> (<code>int</code>, por defecto <code>0</code>): semilla para reproducibilidad.</li>
+<li><code>base_pairs_limit</code> (<code>int</code>, por defecto <code>12</code>): número máximo de pares semilla para búsquedas de orden superior.</li>
+<li><code>beam_width</code> (<code>int</code>, por defecto <code>12</code>): número de candidatos retenidos en cada orden durante la búsqueda en haz.</li>
+<li><code>extend_candidate_pool</code> (<code>int</code> o <code>None</code>, por defecto <code>16</code>): características candidatas aleatorias por padre cuando el orden ≥3.</li>
+<li><code>marginal_gain_min</code> (<code>float</code>, por defecto <code>1e-3</code>): ganancia mínima de sinergia para aceptar una extensión.</li>
+<li><code>max_eval_per_order</code> (<code>int</code> o <code>None</code>, por defecto <code>1000</code>): límite de evaluaciones de información mutua por orden.</li>
+<li><code>time_budget_s</code> (<code>float</code> o <code>None</code>, por defecto <code>None</code>): presupuesto de tiempo global en segundos para <code>fit</code>.</li>
+<li><code>objective</code> (<code>"mi_joint"</code> o <code>"mi_synergy"</code>, por defecto <code>"mi_joint"</code>): puntuación usada para ordenar subespacios.</li>
+<li><code>min_per_order</code> (<code>int</code>, por defecto <code>1</code>): número mínimo de subespacios a conservar por orden.</li>
+</ul>
+
+<h2>Métodos</h2>
+<ul>
+<li><code>fit(X, y)</code> – descubre subespacios y los almacena en <code>results_</code>.</li>
+</ul>
+

--- a/docs/visualization_3d.html
+++ b/docs/visualization_3d.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 7
 ---
 <link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="visualization_3d_es.html">ES</a></div>
 
 <h1>3D Visualization</h1>
 

--- a/docs/visualization_3d_es.html
+++ b/docs/visualization_3d_es.html
@@ -1,0 +1,42 @@
+---
+layout: default
+title: Visualización 3D
+parent: SheShe
+nav_order: 7
+---
+<link rel="stylesheet" href="style.css">
+<div class="lang-switch"><a href="visualization_3d.html">EN</a></div>
+
+<h1>Visualización 3D</h1>
+
+<p>Usa <code>plot_pair_3d</code> para renderizar una superficie de probabilidad o regresión para cualquier par de características.</p>
+
+<h2>Ejemplo</h2>
+<pre><code>from sklearn.datasets import load_iris
+from sheshe import ModalBoundaryClustering
+
+X, y = load_iris(return_X_y=True)
+mbc = ModalBoundaryClustering(random_state=0).fit(X, y)
+
+# superficie básica para las dos primeras características
+mbc.plot_pair_3d(X, pair=(0, 1), class_label=mbc.classes_[0])
+</code></pre>
+
+<h2>Parámetros</h2>
+<ul>
+  <li><code>pair</code> (<code>tuple[int, int]</code>): índices de las dos características a visualizar.</li>
+  <li><code>class_label</code> (<code>int</code> o <code>str</code>, opcional): clase cuya superficie de probabilidad se dibuja. Requerido para clasificación.</li>
+  <li><code>grid_res</code> (<code>int</code>, por defecto <code>50</code>): resolución de la rejilla 3D.</li>
+</ul>
+
+<h2>Ejemplo con Plotly</h2>
+<pre><code>fig = mbc.plot_pair_3d(
+    X,
+    pair=(0, 1),
+    class_label=mbc.classes_[0],
+    grid_res=75,
+    engine="plotly",
+)
+fig.show()
+</code></pre>
+


### PR DESCRIPTION
## Summary
- add top-right language switch button
- translate documentation into Spanish

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a44d8fe8832cb7cf0ace9f14cf47