### PR TITLE
Add client-side language selector to documentation

### DIFF
--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 6
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="cheche_es.html">ES</a></div>
 
 <h1>CheChe</h1>

--- a/docs/cheche_es.html
+++ b/docs/cheche_es.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 6
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="cheche.html">EN</a></div>
 
 <h1>CheChe</h1>

--- a/docs/conventions.html
+++ b/docs/conventions.html
@@ -6,6 +6,7 @@ nav_order: 99
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="conventions_es.html">ES</a></div>
 
 <h1>Documentation Conventions</h1>

--- a/docs/conventions_es.html
+++ b/docs/conventions_es.html
@@ -5,6 +5,7 @@ description: "Estilo y reglas de migración para la documentación de SheShe"
 nav_order: 99
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="conventions.html">EN</a></div>
 
 <h1>Convenciones de documentación</h1>

--- a/docs/experiments_benchmarks.html
+++ b/docs/experiments_benchmarks.html
@@ -5,6 +5,7 @@ nav_order: 98
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="experiments_benchmarks_es.html">ES</a></div>
 <h1>Experiments & Benchmarks</h1>
 <p>This page summarises results from scripts in the <code>benchmark/</code> directory. Each script runs an A/B style comparison with several repetitions and reports the mean runtime, a speedup ratio and any additional metrics specific to the experiment.</p>

--- a/docs/experiments_benchmarks_es.html
+++ b/docs/experiments_benchmarks_es.html
@@ -5,6 +5,7 @@ nav_order: 98
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="experiments_benchmarks.html">EN</a></div>
 <h1>Experimentos y benchmarks</h1>
 <p>Esta página resume resultados de scripts en el directorio <code>benchmark/</code>. Cada script ejecuta una comparación A/B con varias repeticiones y reporta el tiempo medio de ejecución, una razón de aceleración y cualquier métrica adicional específica del experimento.</p>

--- a/docs/highlights.html
+++ b/docs/highlights.html
@@ -6,6 +6,7 @@ nav_order: 2
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="highlights_es.html">ES</a></div>
 
 <h1>Highlights</h1>

--- a/docs/highlights_es.html
+++ b/docs/highlights_es.html
@@ -5,6 +5,7 @@ description: "Qué obtienes con SheShe"
 nav_order: 2
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="highlights.html">EN</a></div>
 
 <h1>Destacados</h1>

--- a/docs/how_it_works.html
+++ b/docs/how_it_works.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 0
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="how_it_works_es.html">ES</a></div>
 
 <h1>How SheShe Works</h1>

--- a/docs/how_it_works_es.html
+++ b/docs/how_it_works_es.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 0
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="how_it_works.html">EN</a></div>
 
 <h1>Cómo funciona SheShe</h1>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@ has_children: true
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="index_es.html">ES</a></div>
 
 <h1>SheShe</h1>

--- a/docs/index_es.html
+++ b/docs/index_es.html
@@ -6,6 +6,7 @@ has_children: true
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="index.html">EN</a></div>
 
 <h1>SheShe</h1>

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -6,6 +6,7 @@ nav_order: 3
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="installation_es.html">ES</a></div>
 
 <h1>Installation</h1>

--- a/docs/installation_es.html
+++ b/docs/installation_es.html
@@ -6,6 +6,7 @@ nav_order: 3
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="installation.html">EN</a></div>
 
 <h1>Instalación</h1>

--- a/docs/key_parameters.html
+++ b/docs/key_parameters.html
@@ -6,6 +6,7 @@ nav_order: 7
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="key_parameters_es.html">ES</a></div>
 
 <h1>Key parameters</h1>

--- a/docs/key_parameters_es.html
+++ b/docs/key_parameters_es.html
@@ -5,6 +5,7 @@ description: "Hiperparámetros importantes y sus efectos"
 nav_order: 7
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="key_parameters.html">EN</a></div>
 
 <h1>Parámetros clave</h1>

--- a/docs/lang.js
+++ b/docs/lang.js
@@ -1,0 +1,44 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const LANG_KEY = 'docs-lang';
+  const defaultLang = 'EN';
+  const currentLang = localStorage.getItem(LANG_KEY) || defaultLang;
+
+  function createSelector() {
+    const select = document.createElement('select');
+    select.innerHTML = '<option value="EN">EN</option><option value="ES">ES</option>';
+    select.value = currentLang;
+    select.addEventListener('change', () => {
+      const lang = select.value;
+      localStorage.setItem(LANG_KEY, lang);
+      const base = window.location.pathname.replace(/_es\.html$/, '.html');
+      const target = lang === 'ES' ? base.replace(/\.html$/, '_es.html') : base;
+      if (window.location.pathname !== target) {
+        window.location.pathname = target;
+      } else {
+        filterNav(lang);
+      }
+    });
+    return select;
+  }
+
+  function filterNav(lang) {
+    document.querySelectorAll('nav a').forEach(a => {
+      const href = a.getAttribute('href');
+      const isSpanish = /_es\.html$/.test(href);
+      const li = a.closest('li');
+      if (!li) return;
+      if ((lang === 'EN' && isSpanish) || (lang === 'ES' && !isSpanish)) {
+        li.style.display = 'none';
+      } else {
+        li.style.display = '';
+      }
+    });
+  }
+
+  const container = document.querySelector('.lang-switch');
+  if (container) {
+    container.innerHTML = '';
+    container.appendChild(createSelector());
+  }
+  filterNav(currentLang);
+});

--- a/docs/limitations.html
+++ b/docs/limitations.html
@@ -6,6 +6,7 @@ nav_order: 8
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="limitations_es.html">ES</a></div>
 
 <h1>Limitations</h1>

--- a/docs/limitations_es.html
+++ b/docs/limitations_es.html
@@ -6,6 +6,7 @@ nav_order: 8
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="limitations.html">EN</a></div>
 
 <h1>Limitaciones</h1>

--- a/docs/method_matrix.html
+++ b/docs/method_matrix.html
@@ -6,6 +6,7 @@ nav_order: 6
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="method_matrix_es.html">ES</a></div>
 
 <h1>Method matrix</h1>

--- a/docs/method_matrix_es.html
+++ b/docs/method_matrix_es.html
@@ -6,6 +6,7 @@ nav_order: 6
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="method_matrix.html">EN</a></div>
 
 <h1>Matriz de métodos</h1>

--- a/docs/modalboundaryclustering.html
+++ b/docs/modalboundaryclustering.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 1
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="modalboundaryclustering_es.html">ES</a></div>
 
 <h1>ModalBoundaryClustering</h1>

--- a/docs/modalboundaryclustering_es.html
+++ b/docs/modalboundaryclustering_es.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 1
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="modalboundaryclustering.html">EN</a></div>
 
 <h1>ModalBoundaryClustering</h1>

--- a/docs/modalscoutensemble.html
+++ b/docs/modalscoutensemble.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 3
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="modalscoutensemble_es.html">ES</a></div>
 
 <h1>ModalScoutEnsemble</h1>

--- a/docs/modalscoutensemble_es.html
+++ b/docs/modalscoutensemble_es.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 3
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="modalscoutensemble.html">EN</a></div>
 
 <h1>ModalScoutEnsemble</h1>

--- a/docs/performance_tips.html
+++ b/docs/performance_tips.html
@@ -6,6 +6,7 @@ nav_order: 9
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="performance_tips_es.html">ES</a></div>
 
 <h1>Performance Tips</h1>

--- a/docs/performance_tips_es.html
+++ b/docs/performance_tips_es.html
@@ -5,6 +5,7 @@ description: "Heurísticas y ajustes para una exploración más rápida"
 nav_order: 9
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="performance_tips.html">EN</a></div>
 
 <h1>Consejos de rendimiento</h1>

--- a/docs/quick_api.html
+++ b/docs/quick_api.html
@@ -6,6 +6,7 @@ nav_order: 5
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="quick_api_es.html">ES</a></div>
 
 <h1>Quick API</h1>

--- a/docs/quick_api_es.html
+++ b/docs/quick_api_es.html
@@ -5,6 +5,7 @@ description: "Objetos públicos expuestos por el paquete SheShe"
 nav_order: 5
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="quick_api.html">EN</a></div>
 
 <h1>API rápida</h1>

--- a/docs/regioninterpreter.html
+++ b/docs/regioninterpreter.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 4
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="regioninterpreter_es.html">ES</a></div>
 
 <h1>RegionInterpreter</h1>

--- a/docs/regioninterpreter_es.html
+++ b/docs/regioninterpreter_es.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 4
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="regioninterpreter.html">EN</a></div>
 
 <h1>RegionInterpreter</h1>

--- a/docs/reproducibility.html
+++ b/docs/reproducibility.html
@@ -6,6 +6,7 @@ nav_order: 4
 ---
 
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="reproducibility_es.html">ES</a></div>
 
 <h1>Reproducibility</h1>

--- a/docs/reproducibility_es.html
+++ b/docs/reproducibility_es.html
@@ -5,6 +5,7 @@ description: "Pasos para recrear el entorno de SheShe"
 nav_order: 4
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="reproducibility.html">EN</a></div>
 
 <h1>Reproducibilidad</h1>

--- a/docs/shushu.html
+++ b/docs/shushu.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 5
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="shushu_es.html">ES</a></div>
 
 <h1>ShuShu</h1>

--- a/docs/shushu_es.html
+++ b/docs/shushu_es.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 5
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="shushu.html">EN</a></div>
 
 <h1>ShuShu</h1>

--- a/docs/style.css
+++ b/docs/style.css
@@ -93,3 +93,15 @@
 .lang-switch a:hover {
   background: var(--accent-color);
 }
+.lang-switch select {
+  background: var(--primary-color);
+  color: #fff;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  border: none;
+  font-size: 0.9rem;
+}
+.lang-switch select:hover {
+  background: var(--accent-color);
+  cursor: pointer;
+}

--- a/docs/subspacescout.html
+++ b/docs/subspacescout.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 2
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="subspacescout_es.html">ES</a></div>
 
 <h1>SubspaceScout</h1>

--- a/docs/subspacescout_es.html
+++ b/docs/subspacescout_es.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 2
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="subspacescout.html">EN</a></div>
 
 <h1>SubspaceScout</h1>

--- a/docs/visualization_3d.html
+++ b/docs/visualization_3d.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 7
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="visualization_3d_es.html">ES</a></div>
 
 <h1>3D Visualization</h1>

--- a/docs/visualization_3d_es.html
+++ b/docs/visualization_3d_es.html
@@ -5,6 +5,7 @@ parent: SheShe
 nav_order: 7
 ---
 <link rel="stylesheet" href="style.css">
+<script src="lang.js"></script>
 <div class="lang-switch"><a href="visualization_3d.html">EN</a></div>
 
 <h1>Visualización 3D</h1>


### PR DESCRIPTION
## Summary
- Add `lang.js` to provide a language selector with EN default and hide non-selected language navigation
- Style selector via `style.css` and include script across documentation pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a9134b08832cb9baad4ab6a8836a