### PR TITLE
docs: showcase images on documentation index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26,6 +26,14 @@ plt.show()
 
 <p>SheShe converts any probabilistic model into an explorer of its own decision landscape. It follows local maxima of class probability or predicted value to uncover crisp, human‑readable regions that respect the supervised boundary of the problem.</p>
 
+<h2>Gallery</h2>
+<p>The images below showcase example classifications produced by SheShe. They live in the <code>images/</code> directory; add new files there to extend the gallery and reference them here.</p>
+<div class="gallery">
+  <img src="../images/sheshe_class_1.png" alt="SheShe classification example 1">
+  <img src="../images/sheshe_class_2.png" alt="SheShe classification example 2">
+  <img src="../images/sheshe_class_3.png" alt="SheShe classification example 3">
+</div>
+
 <p>Learn how SheShe explores local maxima and how its tools operate independently in <a href="how_it_works.html">How it works</a>.</p>
 
 <h2>Getting started</h2>

--- a/docs/index_es.html
+++ b/docs/index_es.html
@@ -26,6 +26,14 @@ plt.show()
 
 <p>SheShe convierte cualquier modelo probabilístico en un explorador de su propia superficie de decisión. Sigue máximos locales de probabilidad por clase o valor predicho para descubrir regiones nítidas y legibles que respetan la frontera supervisada del problema.</p>
 
+<h2>Galería</h2>
+<p>Las imágenes a continuación muestran ejemplos de clasificaciones producidas por SheShe. Están en el directorio <code>images/</code>; agrega nuevos archivos allí para ampliar la galería y refiérelos aquí.</p>
+<div class="gallery">
+  <img src="../images/sheshe_class_1.png" alt="Ejemplo de clasificación SheShe 1">
+  <img src="../images/sheshe_class_2.png" alt="Ejemplo de clasificación SheShe 2">
+  <img src="../images/sheshe_class_3.png" alt="Ejemplo de clasificación SheShe 3">
+</div>
+
 <p>Aprende cómo SheShe explora los máximos locales y cómo sus herramientas operan de forma independiente en <a href="how_it_works_es.html">Cómo funciona</a>.</p>
 
 <h2>Primeros pasos</h2>


### PR DESCRIPTION
## Summary
- add gallery of SheShe classification images to English docs index
- mirror gallery and instructions in Spanish docs index

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7d2bd92d4832c9cfcba0a84a8cc1c