### PR TITLE
fix: correct docs config YAML

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,3 @@
-title: SheShe Documentation
-description: Official documentation for the SheShe library
-remote_theme: just-the-docs/just-the-docs
+title: "SheShe Documentation"
+description: "Official documentation for the SheShe library"
+remote_theme: "just-the-docs/just-the-docs"


### PR DESCRIPTION
## Summary
- fix Jekyll docs configuration YAML syntax

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7d4b029ec832cb2f0fce30fbd101a