### PR TITLE
Add author link to highlights documentation

### DIFF
--- a/docs/highlights.html
+++ b/docs/highlights.html
@@ -24,3 +24,6 @@ nav_order: 2
 
 <p>See the <a href="quick_api.html">Quick API</a> for a full reference of public objects.</p>
 
+<h2>About</h2>
+<p>SheShe is developed by José Carlos Del Valle. Connect on <a href="https://www.linkedin.com/in/jose-carlos-del-valle/">LinkedIn</a> or explore his <a href="https://jcval94.github.io/Portfolio/">portfolio</a>.</p>
+

--- a/docs/highlights_es.html
+++ b/docs/highlights_es.html
@@ -23,3 +23,6 @@ nav_order: 2
 
 <p>Consulta la <a href="quick_api_es.html">API rápida</a> para una referencia completa de los objetos públicos.</p>
 
+<h2>Acerca de</h2>
+<p>SheShe es desarrollado por José Carlos Del Valle. Conecta en <a href="https://www.linkedin.com/in/jose-carlos-del-valle/">LinkedIn</a> o explora su <a href="https://jcval94.github.io/Portfolio/">portafolio</a>.</p>
+


### PR DESCRIPTION
## Summary
- Mention José Carlos Del Valle as author in English highlights page with LinkedIn and portfolio links
- Mention José Carlos Del Valle as author in Spanish highlights page with LinkedIn and portfolio links

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7d5642838832ca3481946b4c505c4