### PR TITLE
docs: add quickstart example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ Requires Python ≥3.9. Install from [PyPI](https://pypi.org/project/sheshe/):
 pip install sheshe
 ```
 
+## Quickstart
+
+```python
+from sheshe import ModalBoundaryClustering
+from sklearn.datasets import load_iris
+from sklearn.ensemble import RandomForestClassifier
+
+iris = load_iris()
+X, y = iris.data, iris.target
+
+sh = ModalBoundaryClustering(RandomForestClassifier(), task="classification").fit(X, y)
+print(sh.predict(X[:5]))
+```
+
 ## Documentation
 See the [documentation](https://jcval94.github.io/SheShe/) for installation, API reference and guides.
 


### PR DESCRIPTION
## Summary
- document Quickstart usage with simple iris demo

## Testing
- `PYTHONPATH=src python - <<'PY'
from sheshe import ModalBoundaryClustering
from sklearn.datasets import load_iris
from sklearn.ensemble import RandomForestClassifier

iris = load_iris()
X, y = iris.data, iris.target

sh = ModalBoundaryClustering(RandomForestClassifier(), task="classification").fit(X, y)
print(sh.predict(X[:5]))
PY`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7d76e65f4832ca4c18e884da9c5f5