### PR TITLE
Add copy button to docs code blocks

### DIFF
--- a/docs/lang.js
+++ b/docs/lang.js
@@ -41,4 +41,24 @@ document.addEventListener('DOMContentLoaded', function() {
     container.appendChild(createSelector());
   }
   filterNav(currentLang);
+
+  // Add copy buttons to code blocks
+  document.querySelectorAll('pre > code').forEach(codeBlock => {
+    const button = document.createElement('button');
+    button.className = 'copy-button';
+    button.type = 'button';
+    button.textContent = 'Copy';
+    const pre = codeBlock.parentNode;
+    pre.style.position = 'relative';
+    pre.appendChild(button);
+    button.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(codeBlock.innerText);
+        button.textContent = 'Copied!';
+        setTimeout(() => { button.textContent = 'Copy'; }, 2000);
+      } catch (err) {
+        button.textContent = 'Error';
+      }
+    });
+  });
 });

--- a/docs/style.css
+++ b/docs/style.css
@@ -54,6 +54,24 @@
   border-radius: 4px;
 }
 
+/* Copy button for code blocks */
+.main-content .copy-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.main-content .copy-button:hover {
+  background: var(--primary-color);
+}
+
 .main-content .doc-image {
   text-align: center;
   margin: 2rem 0;


### PR DESCRIPTION
## Summary
- add JS to inject copy buttons for all `pre > code` blocks
- style copy buttons for visibility and interaction

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8eb0c3aa8832c912204bd5ee5d270