### PR TITLE
docs: add classification image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 SheShe turns probabilistic models into guided explorers of their decision surfaces, revealing human‑readable regions by following local maxima of class probability or predicted value.
 
+![SheShe classification example](images/sheshe_class_1.png)
+
 ## Features
 - Supervised clustering for classification and regression
 - Rule extraction and subspace exploration


### PR DESCRIPTION
## Summary
- show a classification example image in the README

## Testing
- `pytest tests/test_api_parity.py -q` *(fails: ModuleNotFoundError: No module named 'sheshe')*

------
https://chatgpt.com/codex/tasks/task_e_68b7d7b8cb7c832cbdd3f56c5e0b4547