### PR TITLE
Use plot_classes as main plot example in docs

### DIFF
--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -16,8 +16,8 @@ from sklearn.datasets import load_iris
 from sheshe import CheChe
 
 X, y = load_iris(return_X_y=True)
-che = CheChe().fit(X, y)
-che.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+che = CheChe().fit(X, y, max_pairs=1)
+che.plot_classes(X, y)
 plt.show()
 </code></pre>
 <p>Computes convex-hull frontiers for selected feature pairs and provides simple</p>
@@ -32,7 +32,7 @@ plt.show()
 from sheshe import CheChe
 cc = CheChe()
 cc.fit(X, y)
-cc.plot_pairs(X, show_histograms=True)
+cc.plot_classes(X, y)
 </code></pre>
 
 <h2>Usage examples</h2>
@@ -61,7 +61,7 @@ ch = CheChe().fit(
     feature_names=["sepal length", "sepal width", "petal length", "petal width"],
     mapping_level=2,  # use every other sample
 )
-ch.plot_pairs(X, class_index=0, show_histograms=True)
+ch.plot_classes(X, y)
 </code></pre>
 <pre><code class="language-python">
 from sklearn.linear_model import LogisticRegression

--- a/docs/cheche_es.html
+++ b/docs/cheche_es.html
@@ -16,8 +16,8 @@ from sklearn.datasets import load_iris
 from sheshe import CheChe
 
 X, y = load_iris(return_X_y=True)
-che = CheChe().fit(X, y)
-che.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+che = CheChe().fit(X, y, max_pairs=1)
+che.plot_classes(X, y)
 plt.show()
 </code></pre>
 <p>Calcula fronteras de casco convexo para pares de características seleccionados y ofrece visualizaciones 2D simples.</p>
@@ -32,7 +32,7 @@ plt.show()
 from sheshe import CheChe
 cc = CheChe()
 cc.fit(X, y)
-cc.plot_pairs(X, show_histograms=True)
+cc.plot_classes(X, y)
 </code></pre>
 
 <h2>Ejemplos de uso</h2>
@@ -62,7 +62,7 @@ ch = CheChe().fit(
     feature_names=["sepal length", "sepal width", "petal length", "petal width"],
     mapping_level=2,  # usa una de cada dos muestras
 )
-ch.plot_pairs(X, class_index=0, show_histograms=True)
+ch.plot_classes(X, y)
 </code></pre>
 <pre><code class="language-python">
 from sklearn.linear_model import LogisticRegression

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@ from sheshe import ModalBoundaryClustering
 
 X, y = load_iris(return_X_y=True)
 sh = ModalBoundaryClustering().fit(X, y)
-sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+sh.plot_classes(X, y)
 plt.show()
 </code></pre>
 

--- a/docs/index_es.html
+++ b/docs/index_es.html
@@ -18,7 +18,7 @@ from sheshe import ModalBoundaryClustering
 
 X, y = load_iris(return_X_y=True)
 sh = ModalBoundaryClustering().fit(X, y)
-sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+sh.plot_classes(X, y)
 plt.show()
 </code></pre>
 

--- a/docs/modalboundaryclustering.html
+++ b/docs/modalboundaryclustering.html
@@ -17,7 +17,7 @@ from sheshe import ModalBoundaryClustering
 
 X, y = load_iris(return_X_y=True)
 sh = ModalBoundaryClustering().fit(X, y)
-sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0])
+sh.plot_classes(X, y)
 plt.show()
 </code></pre>
 <p>Learns regions of high probability or predicted value by climbing local maxima of a</p>

--- a/docs/modalboundaryclustering_es.html
+++ b/docs/modalboundaryclustering_es.html
@@ -17,7 +17,7 @@ from sheshe import ModalBoundaryClustering
 
 X, y = load_iris(return_X_y=True)
 sh = ModalBoundaryClustering().fit(X, y)
-sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0])
+sh.plot_classes(X, y)
 plt.show()
 </code></pre>
 <p>Aprende regiones de alta probabilidad o valor predicho escalando los máximos locales de un estimador base.</p>

--- a/docs/modalscoutensemble.html
+++ b/docs/modalscoutensemble.html
@@ -17,7 +17,7 @@ from sheshe import ModalScoutEnsemble
 
 X, y = load_iris(return_X_y=True)
 mse = ModalScoutEnsemble().fit(X, y)
-mse.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+mse.plot_classes(X, y)
 plt.show()
 </code></pre>
 <p>Ensemble that applies <code>ModalBoundaryClustering</code> on the most promising</p>

--- a/docs/modalscoutensemble_es.html
+++ b/docs/modalscoutensemble_es.html
@@ -17,7 +17,7 @@ from sheshe import ModalScoutEnsemble
 
 X, y = load_iris(return_X_y=True)
 mse = ModalScoutEnsemble().fit(X, y)
-mse.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+mse.plot_classes(X, y)
 plt.show()
 </code></pre>
 <p>Ensamble que aplica <code>ModalBoundaryClustering</code> en los subespacios más prometedores descubiertos por <code>SubspaceScout</code>. Cada submodelo se pondera por puntuación del scout, validación cruzada e importancia de características, y el ensamble puede delegar la optimización a <code>ShuShu</code> cuando <code>ensemble_method="shushu"</code>.</p>

--- a/docs/regioninterpreter.html
+++ b/docs/regioninterpreter.html
@@ -19,7 +19,7 @@ iris = load_iris()
 X, y = iris.data, iris.target
 sh = ModalBoundaryClustering().fit(X, y)
 cards = RegionInterpreter(feature_names=iris.feature_names).summarize(sh.regions_)
-sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+sh.plot_classes(X, y)
 plt.show()
 </code></pre>
 <p>Converts <code>ClusterRegion</code> objects into compact human‑readable rule sets.</p>

--- a/docs/regioninterpreter_es.html
+++ b/docs/regioninterpreter_es.html
@@ -19,7 +19,7 @@ iris = load_iris()
 X, y = iris.data, iris.target
 sh = ModalBoundaryClustering().fit(X, y)
 cards = RegionInterpreter(feature_names=iris.feature_names).summarize(sh.regions_)
-sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+sh.plot_classes(X, y)
 plt.show()
 </code></pre>
 <p>Convierte objetos <code>ClusterRegion</code> en conjuntos de reglas compactos y legibles. Resume cada región con cajas alineadas a los ejes, destaca proyecciones informativas y ofrece utilidades como <code>pretty_print</code> para reportes. Backends opcionales de LLM pueden transformar los resúmenes en descripciones en lenguaje natural.</p>

--- a/docs/shushu.html
+++ b/docs/shushu.html
@@ -17,7 +17,7 @@ from sheshe import ShuShu
 
 X, y = load_iris(return_X_y=True)
 sh = ShuShu().fit(X, y)
-sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+sh.plot_classes(X, y)
 plt.show()
 </code></pre>
 <p>Gradient-based optimiser that searches for local maxima of a scalar score or</p>

--- a/docs/shushu_es.html
+++ b/docs/shushu_es.html
@@ -17,7 +17,7 @@ from sheshe import ShuShu
 
 X, y = load_iris(return_X_y=True)
 sh = ShuShu().fit(X, y)
-sh.plot_pairs(X, y, max_pairs=1, show_histograms=True)
+sh.plot_classes(X, y)
 plt.show()
 </code></pre>
 <p>Optimizador basado en gradiente que busca máximos locales de una puntuación escalar o probabilidades de clase. Ejecuta una optimización por clase cuando se proporcionan etiquetas y también puede operar sobre funciones de puntuación definidas por el usuario, devolviendo centroides de cada modo descubierto.</p>

--- a/docs/subspacescout.html
+++ b/docs/subspacescout.html
@@ -18,7 +18,7 @@ from sheshe import SubspaceScout, ModalBoundaryClustering
 X, y = load_iris(return_X_y=True)
 scout = SubspaceScout().fit(X, y)
 pair = scout.results_[0]["features"]
-ModalBoundaryClustering().fit(X, y).plot_pairs(X, y, pairs=[pair], show_histograms=True)
+ModalBoundaryClustering().fit(X[:, pair], y).plot_classes(X[:, pair], y)
 plt.show()
 </code></pre>
 <p>Identifies informative feature subsets so that <code>ModalBoundaryClustering</code> can</p>

--- a/docs/subspacescout_es.html
+++ b/docs/subspacescout_es.html
@@ -18,7 +18,7 @@ from sheshe import SubspaceScout, ModalBoundaryClustering
 X, y = load_iris(return_X_y=True)
 scout = SubspaceScout().fit(X, y)
 pair = scout.results_[0]["features"]
-ModalBoundaryClustering().fit(X, y).plot_pairs(X, y, pairs=[pair], show_histograms=True)
+ModalBoundaryClustering().fit(X[:, pair], y).plot_classes(X[:, pair], y)
 plt.show()
 </code></pre>
 <p>Identifica subconjuntos de características informativos para que <code>ModalBoundaryClustering</code> se ejecute solo donde importa en espacios de alta dimensión. Usa información mutua u opcionalmente calificadores basados en modelos para clasificar interacciones y emplea búsqueda en haz para enumerar subespacios prometedores.</p>


### PR DESCRIPTION
## Summary
- Replace `plot_pairs` and `plot_pair_3d` examples with `plot_classes` across predictor documentation
- Standardize plotting guidance in both English and Spanish docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b91bb6310c832cb129a9b204f84773