### PR TITLE
docs: destacar enlace de documentación en readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # SheShe
 <div align="right"><a href="README_ES.md">ES</a></div>
+ 
+**📚 Full documentation:** https://jcval94.github.io/SheShe/
+
 **Smart High-dimensional Edge Segmentation & Hyperboundary Explorer**
 
 SheShe turns probabilistic models into guided explorers of their decision surfaces, revealing human‑readable regions by following local maxima of class probability or predicted value.

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,5 +1,8 @@
 # SheShe
 <div align="right"><a href="README.md">EN</a></div>
+
+**📚 Documentación completa:** https://jcval94.github.io/SheShe/
+
 **Smart High-dimensional Edge Segmentation & Hyperboundary Explorer**
 
 SheShe convierte cualquier modelo probabilístico en un explorador guiado de su superficie de decisión, descubriendo regiones interpretables a partir de los máximos locales de probabilidad por clase o valor predicho.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,8 +1,8 @@
 # Resultados de benchmarks
 
-Este directorio contiene los resultados de pruebas de rendimiento y calidad para `SheShe` comparado con otros algoritmos clásicos.
+**📚 Documentación:** https://jcval94.github.io/SheShe/
 
-Para documentación completa de SheShe, visita [jcval94.github.io/SheShe](https://jcval94.github.io/SheShe/).
+Este directorio contiene los resultados de pruebas de rendimiento y calidad para `SheShe` comparado con otros algoritmos clásicos.
 
 ## Calidad de clustering
 

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,9 +1,9 @@
 # Experimentos para el manuscrito
 
+**📚 Documentación:** https://jcval94.github.io/SheShe/
+
 Este directorio contiene scripts reproducibles que generan las tablas y figuras
 utilizadas en el artículo de SheShe.
-
-Para documentación completa de SheShe, visita [jcval94.github.io/SheShe](https://jcval94.github.io/SheShe/).
 
 Las métricas reflejan el nuevo modo de rayos `grad`, que reemplaza al anterior
 `grid` con mejoras significativas de rendimiento (ver


### PR DESCRIPTION
## Summary
- Resalta el enlace a la documentación del proyecto al inicio de todos los README.

## Testing
- `pytest -q` *(se interrumpe, no se ejecutaron pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_68b920efb854832ca46c7e7f6edfadac