### PR TITLE
Add regression fit time experiment

### DIFF
--- a/benchmark/regression_fit_times.csv
+++ b/benchmark/regression_fit_times.csv
@@ -1,0 +1,5 @@
+predictor,fit_time_s,status
+ModalBoundaryClustering,0.12451899999999227,ok
+ShuShu,,ValueError
+CheChe,0.005849838999978374,ok
+ModalScoutEnsemble,0.29596378499999787,ok

--- a/experiments/regression_fit_times.py
+++ b/experiments/regression_fit_times.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pandas as pd
+from sklearn.datasets import make_regression
+from sklearn.linear_model import LinearRegression
+
+from sheshe import (
+    CheChe,
+    ModalBoundaryClustering,
+    ModalScoutEnsemble,
+    ShuShu,
+)
+
+
+def main() -> None:
+    X, y = make_regression(n_samples=200, n_features=3, noise=0.1, random_state=0)
+
+    predictors = [
+        ("ModalBoundaryClustering", ModalBoundaryClustering(task="regression")),
+        ("ShuShu", ShuShu()),
+        ("CheChe", CheChe()),
+        (
+            "ModalScoutEnsemble",
+            ModalScoutEnsemble(base_estimator=LinearRegression(), task="regression"),
+        ),
+    ]
+
+    results = []
+    for name, estimator in predictors:
+        score_model = LinearRegression().fit(X, y)
+        start = time.perf_counter()
+        try:
+            estimator.fit(X, y, score_model=score_model)
+            elapsed = time.perf_counter() - start
+            results.append({"predictor": name, "fit_time_s": elapsed, "status": "ok"})
+        except Exception as exc:  # noqa: BLE001 - capture all for reporting
+            results.append(
+                {
+                    "predictor": name,
+                    "fit_time_s": float("nan"),
+                    "status": type(exc).__name__,
+                }
+            )
+
+    df = pd.DataFrame(results)
+    out_path = Path(__file__).resolve().parent.parent / "benchmark" / "regression_fit_times.csv"
+    df.to_csv(out_path, index=False)
+    print(df)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to benchmark fit times of modal predictors on a simple regression dataset
- store run results in `benchmark/regression_fit_times.csv`

## Testing
- `PYTHONPATH=src python experiments/regression_fit_times.py`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b92740416c832c873286aa47725a22