### PR TITLE
Enable transform for CheChe and add coverage

### DIFF
--- a/src/sheshe/cheche.py
+++ b/src/sheshe/cheche.py
@@ -438,8 +438,15 @@ class CheChe:
         return df
 
     def transform(self, X: npt.NDArray[np.float_] | pd.DataFrame) -> npt.NDArray[np.float_]:
-        """Feature transformation is not available for CheChe."""
-        raise NotImplementedError("CheChe does not implement transform")
+        """Return negative distances to region centers for ``X``.
+
+        This mirrors the behaviour of :meth:`decision_function` and provides a
+        simple embedding where each feature corresponds to how close a sample is
+        to a discovered region.  The output array has shape ``(n_samples,
+        n_regions)``.
+        """
+
+        return self.decision_function(X)
 
     def fit_transform(
         self,
@@ -447,14 +454,14 @@ class CheChe:
         y: Optional[npt.NDArray] = None,
         **fit_kwargs: Any,
     ) -> npt.NDArray[np.float_]:
-        """Fit to data, then transform it.
+        """Fit the model to ``X`` and ``y`` then return the transformed data.
 
-        Notes
-        -----
-        ``CheChe`` lacks a transformation step and this method always raises
-        ``NotImplementedError``.
+        This method is equivalent to calling :meth:`fit` followed by
+        :meth:`transform`.
         """
-        raise NotImplementedError("CheChe does not implement fit_transform")
+
+        self.fit(X, y, **fit_kwargs)
+        return self.transform(X)
 
     def score(
         self,

--- a/tests/test_api_parity.py
+++ b/tests/test_api_parity.py
@@ -82,20 +82,22 @@ def test_common_prediction_api(name, ctor, plot_kwargs, pass_y, monkeypatch):
     plt.close("all")
 
 
-@pytest.mark.parametrize("name,ctor", [("mbc", _make_mbc), ("shushu", _make_shushu)])
+@pytest.mark.parametrize(
+    "name,ctor", [("mbc", _make_mbc), ("shushu", _make_shushu), ("cheche", _make_cheche)]
+)
 def test_transform_shapes(name, ctor):
     X, y = load_iris(return_X_y=True)
     model = ctor()
     model.fit(X, y)
     T = model.transform(X)
     assert T.shape[0] == X.shape[0]
-    if name == "mbc":
+    if name in {"mbc", "cheche"}:
         assert T.shape[1] == len(model.regions_)
     else:
         assert T.shape[1] == len(model.classes_)
 
 
-@pytest.mark.parametrize("ctor", [_make_cheche, _make_mse])
+@pytest.mark.parametrize("ctor", [_make_mse])
 def test_transform_not_implemented(ctor):
     X, y = load_iris(return_X_y=True)
     model = ctor()

--- a/tests/test_api_standardization.py
+++ b/tests/test_api_standardization.py
@@ -29,8 +29,8 @@ def test_cheche_save_load_score(tmp_path):
     df = ch.predict_regions(X[:2])
     assert set(df.columns) == {"label", "region_id"}
     assert isinstance(ch.score(X[:2], y[:2]), float)
-    with pytest.raises(NotImplementedError):
-        ch.transform(X[:2])
+    T = ch.transform(X[:2])
+    assert T.shape == (2, len(ch.regions_))
     path = tmp_path / "ch.joblib"
     ch.save(path)
     loaded = CheChe.load(path)

--- a/tests/test_cheche_transform.py
+++ b/tests/test_cheche_transform.py
@@ -1,0 +1,25 @@
+import numpy as np
+from sklearn.datasets import load_iris
+
+from sheshe import CheChe
+
+
+def test_transform_negative_distances():
+    X, y = load_iris(return_X_y=True)
+    ch = CheChe().fit(X, y)
+    T = ch.transform(X)
+    assert T.shape == (X.shape[0], len(ch.regions_))
+    for idx, reg in enumerate(ch.regions_):
+        dims = reg["dims"]
+        center = reg["center"]
+        dists = -np.linalg.norm(X[:, list(dims)] - center, axis=1)
+        assert np.allclose(T[:, idx], dists)
+
+
+def test_fit_transform_equivalent():
+    X, y = load_iris(return_X_y=True)
+    ch1 = CheChe()
+    D1 = ch1.fit_transform(X, y)
+    ch2 = CheChe().fit(X, y)
+    D2 = ch2.transform(X)
+    assert np.allclose(D1, D2)


### PR DESCRIPTION
## Summary
- implement `transform` returning negative distances to region centers
- add `fit_transform` that runs `fit` then `transform`
- extend and adjust tests for new transformation behavior

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9b2d9a804832cb393f6349f36b3b3