### PR TITLE
feat: add score-based frontier option

### DIFF
--- a/docs/cheche.html
+++ b/docs/cheche.html
@@ -24,6 +24,7 @@ plt.show()
 <p>2D visualisations. Useful for exploring decision boundaries or cluster shapes,</p>
 <p>it can subsample points via <code>mapping_level</code> and plot frontiers per class or</p>
 <p>for scalar score functions.</p>
+<p>Frontiers can also follow a score function contour when <code>score_frontier</code> is provided.</p>
 <h2>Mathematical formulation</h2>
 <p>For feature pair <code>(i,j)</code>, CheChe projects samples with <code>P_{ij}(x) = (x_i, x_j)</code>. QuickHull constructs the convex hull <code>H</code> of these projections.</p>
 <p>The decision function outputs the negative distance from the projected point to the hull centroid: <code>-‖P_{ij}(x) - c_H‖</code>.</p>
@@ -71,6 +72,9 @@ CheChe().fit(X, y, score_model=model)
 
 score_fn = lambda Z: model.predict_proba(Z)[:, 0]
 CheChe().fit(X, score_fn=score_fn)
+
+che = CheChe().fit(X, score_fn=score_fn, score_frontier=0.8, grid_res=40)
+che.plot_pairs(X)
 </code></pre>
 <h2>Parameters</h2>
 <ul>
@@ -97,6 +101,8 @@ CheChe().fit(X, score_fn=score_fn)
 <li><code>mapping_level</code> (<code>int</code> or <code>None</code>, default <code>None</code>): down-sampling level for
  frontier computation.
 </li>
+<li><code>score_frontier</code> (<code>float</code>, optional): contour level for score-based frontiers when a <code>score_fn</code> is supplied.</li>
+<li><code>grid_res</code> (<code>int</code>, default <code>200</code>): evaluation grid resolution used for score-based frontiers.</li>
 </ul>
 <h2>Methods</h2>
 <ul>

--- a/docs/cheche_es.html
+++ b/docs/cheche_es.html
@@ -22,6 +22,7 @@ plt.show()
 </code></pre>
 <p>Calcula fronteras de casco convexo para pares de características seleccionados y ofrece visualizaciones 2D simples.</p>
 <p>Útil para explorar fronteras de decisión o formas de clusters, puede submuestrear puntos mediante <code>mapping_level</code> y trazar fronteras por clase o para funciones de puntuación escalares.</p>
+<p>Las fronteras también pueden seguir el contorno de una función de puntuación especificando <code>score_frontier</code>.</p>
 
 <h2>Formulación matemática</h2>
 <p>Para el par de características <code>(i,j)</code>, CheChe proyecta muestras con <code>P_{ij}(x) = (x_i, x_j)</code>. QuickHull construye el casco convexo <code>H</code> de estas proyecciones.</p>
@@ -72,6 +73,9 @@ CheChe().fit(X, y, score_model=model)
 
 score_fn = lambda Z: model.predict_proba(Z)[:, 0]
 CheChe().fit(X, score_fn=score_fn)
+
+che = CheChe().fit(X, score_fn=score_fn, score_frontier=0.8, grid_res=40)
+che.plot_pairs(X)
 </code></pre>
 
 <h2>Parámetros</h2>
@@ -89,6 +93,8 @@ CheChe().fit(X, score_fn=score_fn)
 <li><code>score_fn_per_class</code> (<code>list[callable]</code>, opcional): funciones de puntuación por clase.</li>
 <li><code>max_pairs</code> (<code>int</code> o <code>None</code>, por defecto <code>10</code>): número máximo de pares de características a analizar.</li>
 <li><code>mapping_level</code> (<code>int</code> o <code>None</code>, por defecto <code>None</code>): nivel de submuestreo para la computación de fronteras.</li>
+<li><code>score_frontier</code> (<code>float</code>, opcional): nivel del contorno para fronteras basadas en la función de puntuación.</li>
+<li><code>grid_res</code> (<code>int</code>, por defecto <code>200</code>): resolución de la malla de evaluación para fronteras basadas en puntuación.</li>
 </ul>
 
 <h2>Métodos</h2>


### PR DESCRIPTION
## Summary
- allow `CheChe` to derive regions from score function contours via new `score_frontier` parameter
- compute score-based frontiers on a grid with configurable resolution
- test score-based frontier generation
- document score-frontier usage in English and Spanish HTML guides

## Testing
- `PYTHONPATH=src pytest tests/test_cheche_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba0528a134832ca69a70362003c67d