### PR TITLE
Add RandomForest-based feature selection for high-dimensional CheChe

### DIFF
--- a/tests/test_cheche_feature_selection.py
+++ b/tests/test_cheche_feature_selection.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from sheshe import CheChe
+
+
+def test_feature_selection_reduces_dims_and_predicts():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(100, 10))
+    y = X[:, 0] + 0.1 * rng.normal(size=100)
+    ch = CheChe(random_state=0).fit(X, y)
+    assert ch.selected_features_ is not None
+    assert len(ch.selected_features_) < X.shape[1]
+    preds = ch.predict(X)
+    assert preds.shape[0] == X.shape[0]


### PR DESCRIPTION
## Summary
- Use RandomForestRegressor to drop low-importance features when dimension combinations exceed 16
- Apply selected feature subset across prediction and summary paths
- Test feature-selection flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbc5f27b9c832cb99961c5035b4c14