### PR TITLE
Add scatter points to 3D pair plots

### DIFF
--- a/docs/visualization_3d.html
+++ b/docs/visualization_3d.html
@@ -11,7 +11,8 @@ nav_order: 7
 <h1>3D Visualization</h1>
 
 <p>Use <code>plot_pair_3d</code> to render a probability or regression surface
-for any pair of features.</p>
+for any pair of features, along with the original data points as a scatter
+plot.</p>
 
 <h2>Example</h2>
 <pre><code>from sklearn.datasets import load_iris

--- a/docs/visualization_3d_es.html
+++ b/docs/visualization_3d_es.html
@@ -10,7 +10,9 @@ nav_order: 7
 
 <h1>Visualización 3D</h1>
 
-<p>Usa <code>plot_pair_3d</code> para renderizar una superficie de probabilidad o regresión para cualquier par de características.</p>
+<p>Usa <code>plot_pair_3d</code> para renderizar una superficie de probabilidad o
+regresión para cualquier par de características, junto con los puntos de datos
+originales en un scatterplot.</p>
 
 <h2>Ejemplo</h2>
 <pre><code>from sklearn.datasets import load_iris

--- a/src/sheshe/sheshe.py
+++ b/src/sheshe/sheshe.py
@@ -3044,6 +3044,9 @@ class ModalBoundaryClustering(BaseEstimator):
             X_full[:, j] = XJ[r, :]
             Z[r, :] = self._predict_value_real(X_full, class_idx=class_idx)
 
+        # predictions for the original samples to overlay as a scatter plot
+        z_points = self._predict_value_real(X_arr, class_idx=class_idx)
+
         if engine == "plotly":
             try:
                 import plotly.graph_objects as go
@@ -3060,7 +3063,14 @@ class ModalBoundaryClustering(BaseEstimator):
                         z=Z,
                         colorscale="Viridis",
                         opacity=alpha_surface,
-                    )
+                    ),
+                    go.Scatter3d(
+                        x=xi,
+                        y=xj,
+                        z=z_points,
+                        mode="markers",
+                        marker=dict(size=3, color="black"),
+                    ),
                 ]
             )
             fig.update_layout(
@@ -3079,6 +3089,7 @@ class ModalBoundaryClustering(BaseEstimator):
         fig = plt.figure(figsize=(6, 5))
         ax = fig.add_subplot(111, projection="3d")
         ax.plot_surface(XI, XJ, Z, cmap="viridis", alpha=alpha_surface)
+        ax.scatter(xi, xj, z_points, c="k", s=15)
         ax.set_xlabel(feature_names[i])
         ax.set_ylabel(feature_names[j])
         ax.set_zlabel(zlabel)

--- a/src/sheshe/shushu.py
+++ b/src/sheshe/shushu.py
@@ -1348,6 +1348,9 @@ class ShuShu:
         base[:, d2] = XX2.ravel()
         ZZ = score_fn(base).reshape(grid_res, grid_res)
 
+        # score/predictions for original samples for scatter overlay
+        Z_points = score_fn(X)
+
         if engine == "plotly":
             try:
                 import plotly.graph_objects as go
@@ -1355,7 +1358,14 @@ class ShuShu:
                 raise ImportError("plotly is required when engine='plotly'") from exc
             fig = go.Figure(
                 data=[
-                    go.Surface(x=XX1, y=XX2, z=ZZ, colorscale="Viridis", opacity=alpha_surface)
+                    go.Surface(x=XX1, y=XX2, z=ZZ, colorscale="Viridis", opacity=alpha_surface),
+                    go.Scatter3d(
+                        x=X[:, d1],
+                        y=X[:, d2],
+                        z=Z_points,
+                        mode="markers",
+                        marker=dict(size=3, color="black"),
+                    ),
                 ]
             )
             fig.update_layout(
@@ -1370,6 +1380,7 @@ class ShuShu:
         fig = plt.figure(figsize=(6, 5))
         ax = fig.add_subplot(111, projection="3d")
         ax.plot_surface(XX1, XX2, ZZ, cmap="viridis", alpha=alpha_surface)
+        ax.scatter(X[:, d1], X[:, d2], Z_points, c="k", s=15)
         ax.set_xlabel(name1)
         ax.set_ylabel(name2)
         ax.set_zlabel(zlabel)

--- a/tests/test_plot_pair_3d.py
+++ b/tests/test_plot_pair_3d.py
@@ -1,6 +1,7 @@
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d.art3d import Path3DCollection
 
 import pytest
 from sklearn.datasets import load_iris
@@ -10,7 +11,10 @@ from sheshe import ModalBoundaryClustering
 def test_plot_pair_3d_runs():
     X, y = load_iris(return_X_y=True)
     sh = ModalBoundaryClustering(random_state=0).fit(X, y)
-    sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0])
+    fig = sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0])
+    ax = fig.axes[0]
+    assert any(isinstance(c, Path3DCollection) for c in ax.collections)
+    plt.close(fig)
 
 
 def test_plot_pair_3d_plotly_runs():
@@ -19,6 +23,8 @@ def test_plot_pair_3d_plotly_runs():
     sh = ModalBoundaryClustering(random_state=0).fit(X, y)
     fig = sh.plot_pair_3d(X, (0, 1), class_label=sh.classes_[0], engine="plotly")
     assert fig is not None
+    assert len(fig.data) == 2
+    assert fig.data[1].type == "scatter3d"
 
 
 def test_plot_pair_3d_bad_engine():


### PR DESCRIPTION
## Summary
- Overlay original sample points as scatter markers in `plot_pair_3d` for both matplotlib and plotly engines
- Document that `plot_pair_3d` now displays data points along with the surface
- Add regression tests ensuring scatter traces are generated

## Testing
- `PYTHONPATH=src pytest tests/test_plot_pair_3d.py tests/test_modal_scout_ensemble_plots.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc75115ac4832c9aaaafe09de24ecb